### PR TITLE
FastAPI backend scaffold (Issue #52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           CI: true
         run: |
           mkdir -p reports
-          poetry run pytest --junitxml=reports/junit.xml --cov=src --cov-report=xml:reports/coverage.xml -q
+          poetry run pytest --junitxml=reports/junit.xml --cov=pipeline --cov-report=xml:reports/coverage.xml -q
 
       - name: Upload test report to GitHub checks
         uses: dorny/test-reporter@v2
@@ -101,3 +101,25 @@ jobs:
         with:
           files: reports/coverage.xml
           fail_ci_if_error: false
+
+  test-backend:
+    name: Backend test suite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Run backend tests
+        working-directory: backend
+        run: pytest tests/ -q

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Indy Explorer API")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.12
+uvicorn[standard]==0.34.0
+pandas==2.2.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,7 @@
 fastapi==0.115.12
 uvicorn[standard]==0.34.0
 pandas==2.2.3
+
+# dev/test
+httpx==0.28.1
+pytest==8.3.5

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary

- `backend/main.py` — FastAPI app with `GET /health` → `{"status": "ok"}`
- `backend/requirements.txt` — pinned dependencies: fastapi, uvicorn, pandas, httpx, pytest
- `backend/Dockerfile` — Python 3.12-slim image, runs uvicorn on port 8000
- `backend/tests/test_health.py` — pytest test using FastAPI's `TestClient`
- CI updated with a `test-backend` job that installs from `backend/requirements.txt` and runs `pytest tests/` from `backend/`
- Fixed stale `--cov=src` reference in CI (now `--cov=pipeline`)

Closes #52

## Test plan
- [x] `GET /health` returns `{"status": "ok"}`
- [x] `uvicorn main:app` starts without errors from `backend/`
- [x] All CI jobs pass (Format, Test suite, Backend test suite)
- [x] `docker build` succeeds and container responds to `GET /health`

## Notes
Local dev setup (Vite proxy for frontend + backend together) has been added to the acceptance criteria for Issue #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)