### PR TITLE
GET /resorts Peak Rankings filters (Issue #59)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -49,8 +49,9 @@ def get_resorts(
     has_snowshoeing: Optional[bool] = Query(default=None),
     is_allied: Optional[bool] = Query(default=None),
     ltt_available: Optional[bool] = Query(default=None),
+    has_peak_rankings: Optional[bool] = Query(default=None),
     reservation_required: Optional[bool] = Query(default=None),
-    # Numeric range filters (inclusive)
+    # Numeric range filters (inclusive; resorts with null values are excluded)
     min_vertical: Optional[float] = Query(default=None),
     max_vertical: Optional[float] = Query(default=None),
     min_trails: Optional[float] = Query(default=None),
@@ -59,6 +60,35 @@ def get_resorts(
     max_lifts: Optional[float] = Query(default=None),
     min_trail_length: Optional[float] = Query(default=None),
     max_trail_length: Optional[float] = Query(default=None),
+    # Peak Rankings score range filters (inclusive; resorts with null values are excluded)
+    pr_total_min: Optional[float] = Query(default=None),
+    pr_total_max: Optional[float] = Query(default=None),
+    pr_snow_min: Optional[float] = Query(default=None),
+    pr_snow_max: Optional[float] = Query(default=None),
+    pr_resiliency_min: Optional[float] = Query(default=None),
+    pr_resiliency_max: Optional[float] = Query(default=None),
+    pr_size_min: Optional[float] = Query(default=None),
+    pr_size_max: Optional[float] = Query(default=None),
+    pr_terrain_diversity_min: Optional[float] = Query(default=None),
+    pr_terrain_diversity_max: Optional[float] = Query(default=None),
+    pr_challenge_min: Optional[float] = Query(default=None),
+    pr_challenge_max: Optional[float] = Query(default=None),
+    pr_lifts_min: Optional[float] = Query(default=None),
+    pr_lifts_max: Optional[float] = Query(default=None),
+    pr_crowd_flow_min: Optional[float] = Query(default=None),
+    pr_crowd_flow_max: Optional[float] = Query(default=None),
+    pr_facilities_min: Optional[float] = Query(default=None),
+    pr_facilities_max: Optional[float] = Query(default=None),
+    pr_navigation_min: Optional[float] = Query(default=None),
+    pr_navigation_max: Optional[float] = Query(default=None),
+    pr_mountain_aesthetic_min: Optional[float] = Query(default=None),
+    pr_mountain_aesthetic_max: Optional[float] = Query(default=None),
+    # Peak Rankings categorical multi-value filters
+    pr_lodging: list[str] = Query(default=[]),
+    pr_apres_ski: list[str] = Query(default=[]),
+    pr_access_road: list[str] = Query(default=[]),
+    pr_ability_low: list[str] = Query(default=[]),
+    pr_ability_high: list[str] = Query(default=[]),
     # Blackout date filters (comma-separated YYYY-MM-DD dates)
     blackout_dates: Optional[str] = Query(default=None),
     ltt_dates: Optional[str] = Query(default=None),
@@ -103,6 +133,12 @@ def get_resorts(
         if value is not None:
             results = [r for r in results if getattr(r, field) == value]
 
+    if has_peak_rankings is not None:
+        if has_peak_rankings:
+            results = [r for r in results if r.pr_total is not None]
+        else:
+            results = [r for r in results if r.pr_total is None]
+
     if reservation_required is not None:
         if reservation_required:
             results = [r for r in results if r.reservation_status == 'Required']
@@ -115,6 +151,17 @@ def get_resorts(
         ('num_trails', min_trails, max_trails),
         ('num_lifts', min_lifts, max_lifts),
         ('trail_length_mi', min_trail_length, max_trail_length),
+        ('pr_total', pr_total_min, pr_total_max),
+        ('pr_snow', pr_snow_min, pr_snow_max),
+        ('pr_resiliency', pr_resiliency_min, pr_resiliency_max),
+        ('pr_size', pr_size_min, pr_size_max),
+        ('pr_terrain_diversity', pr_terrain_diversity_min, pr_terrain_diversity_max),
+        ('pr_challenge', pr_challenge_min, pr_challenge_max),
+        ('pr_lifts', pr_lifts_min, pr_lifts_max),
+        ('pr_crowd_flow', pr_crowd_flow_min, pr_crowd_flow_max),
+        ('pr_facilities', pr_facilities_min, pr_facilities_max),
+        ('pr_navigation', pr_navigation_min, pr_navigation_max),
+        ('pr_mountain_aesthetic', pr_mountain_aesthetic_min, pr_mountain_aesthetic_max),
     ]
     for field, lo, hi in range_filters:
         if lo is not None:
@@ -125,6 +172,19 @@ def get_resorts(
             results = [
                 r for r in results if getattr(r, field) is not None and getattr(r, field) <= hi
             ]
+
+    # Peak Rankings categorical multi-value filters
+    categorical_filters = [
+        ('pr_lodging', pr_lodging),
+        ('pr_apres_ski', pr_apres_ski),
+        ('pr_access_road', pr_access_road),
+        ('pr_ability_low', pr_ability_low),
+        ('pr_ability_high', pr_ability_high),
+    ]
+    for field, values in categorical_filters:
+        if values:
+            value_set = {v.lower() for v in values}
+            results = [r for r in results if (getattr(r, field) or '').lower() in value_set]
 
     # Blackout date filters — exclude resorts blacked out on any of the given dates
     if blackout_dates:

--- a/backend/models.py
+++ b/backend/models.py
@@ -29,6 +29,8 @@ class ResortSummary(BaseModel):
     num_trails: Optional[float] = None
     num_lifts: Optional[float] = None
     trail_length_mi: Optional[float] = None
+    pr_total: Optional[float] = None
+    pr_overall_rank: Optional[float] = None
 
 
 class Resort(BaseModel):

--- a/backend/tests/test_resorts_pr_filters.py
+++ b/backend/tests/test_resorts_pr_filters.py
@@ -1,0 +1,231 @@
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from main import app
+from models import Resort
+
+
+def make_resort(resort_id, name, **kwargs):
+    return Resort(
+        resort_id=resort_id,
+        name=name,
+        region='West',
+        reservation_status='Not Required',
+        indy_page=f'https://example.com/{resort_id}',
+        **kwargs,
+    )
+
+
+FAKE_RESORTS = [
+    make_resort(
+        'id-1',
+        'Peak A',
+        pr_total=85.0,
+        pr_snow=9.0,
+        pr_resiliency=8.0,
+        pr_size=7.0,
+        pr_terrain_diversity=8.5,
+        pr_challenge=9.0,
+        pr_lifts=7.5,
+        pr_crowd_flow=8.0,
+        pr_facilities=7.0,
+        pr_navigation=8.0,
+        pr_mountain_aesthetic=9.0,
+        pr_lodging='yes',
+        pr_apres_ski='extensive',
+        pr_access_road='good',
+        pr_ability_low='beginner',
+        pr_ability_high='expert',
+    ),
+    make_resort(
+        'id-2',
+        'Peak B',
+        pr_total=60.0,
+        pr_snow=6.0,
+        pr_resiliency=5.0,
+        pr_size=6.0,
+        pr_terrain_diversity=6.0,
+        pr_challenge=6.0,
+        pr_lifts=5.0,
+        pr_crowd_flow=6.0,
+        pr_facilities=6.0,
+        pr_navigation=6.0,
+        pr_mountain_aesthetic=6.0,
+        pr_lodging='limited',
+        pr_apres_ski='moderate',
+        pr_access_road='acceptable',
+        pr_ability_low='intermediate',
+        pr_ability_high='advanced',
+    ),
+    make_resort(
+        'id-3',
+        'No Rankings',
+        # no PR fields — simulates a resort without Peak Rankings data
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def patch_resorts():
+    with patch('main._resorts', FAKE_RESORTS):
+        yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# --- has_peak_rankings ---
+
+
+def test_has_peak_rankings_true(client):
+    response = client.get('/resorts?has_peak_rankings=true')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A', 'Peak B'}
+
+
+def test_has_peak_rankings_false(client):
+    response = client.get('/resorts?has_peak_rankings=false')
+    names = {r['name'] for r in response.json()}
+    assert names == {'No Rankings'}
+
+
+def test_pr_total_and_rank_in_response(client):
+    response = client.get('/resorts')
+    for r in response.json():
+        assert 'pr_total' in r
+        assert 'pr_overall_rank' in r
+
+
+# --- pr_total range ---
+
+
+def test_pr_total_min(client):
+    response = client.get('/resorts?pr_total_min=70')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A'}
+
+
+def test_pr_total_max(client):
+    response = client.get('/resorts?pr_total_max=70')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak B'}
+
+
+def test_pr_total_range(client):
+    response = client.get('/resorts?pr_total_min=55&pr_total_max=80')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak B'}
+
+
+def test_pr_total_excludes_null(client):
+    response = client.get('/resorts?pr_total_min=1')
+    names = {r['name'] for r in response.json()}
+    assert 'No Rankings' not in names
+
+
+# --- per-category score ranges ---
+
+
+def test_pr_snow_min(client):
+    response = client.get('/resorts?pr_snow_min=8')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A'}
+
+
+def test_pr_size_max(client):
+    response = client.get('/resorts?pr_size_max=6')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak B'}
+
+
+def test_pr_challenge_range(client):
+    response = client.get('/resorts?pr_challenge_min=5&pr_challenge_max=7')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak B'}
+
+
+def test_category_score_excludes_null(client):
+    response = client.get('/resorts?pr_snow_min=1')
+    names = {r['name'] for r in response.json()}
+    assert 'No Rankings' not in names
+
+
+# --- categorical multi-value filters ---
+
+
+def test_pr_lodging_single(client):
+    response = client.get('/resorts?pr_lodging=yes')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A'}
+
+
+def test_pr_lodging_multi(client):
+    response = client.get('/resorts?pr_lodging=yes&pr_lodging=limited')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A', 'Peak B'}
+
+
+def test_pr_apres_ski(client):
+    response = client.get('/resorts?pr_apres_ski=extensive')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A'}
+
+
+def test_pr_access_road(client):
+    response = client.get('/resorts?pr_access_road=good&pr_access_road=acceptable')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A', 'Peak B'}
+
+
+def test_pr_ability_low(client):
+    response = client.get('/resorts?pr_ability_low=beginner')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A'}
+
+
+def test_pr_ability_high(client):
+    response = client.get('/resorts?pr_ability_high=expert')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A'}
+
+
+def test_categorical_excludes_no_data_resorts(client):
+    # 'No Rankings' has no pr_lodging — should not match any value filter
+    response = client.get('/resorts?pr_lodging=yes&pr_lodging=limited&pr_lodging=no')
+    names = {r['name'] for r in response.json()}
+    assert 'No Rankings' not in names
+
+
+def test_categorical_case_insensitive(client):
+    response = client.get('/resorts?pr_lodging=YES')
+    names = {r['name'] for r in response.json()}
+    assert 'Peak A' in names
+
+
+# --- composability ---
+
+
+def test_has_peak_rankings_and_pr_total_min(client):
+    response = client.get('/resorts?has_peak_rankings=true&pr_total_min=70')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A'}
+
+
+def test_score_range_and_categorical(client):
+    response = client.get('/resorts?pr_total_min=50&pr_lodging=limited')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak B'}
+
+
+def test_multiple_categorical_filters(client):
+    response = client.get('/resorts?pr_lodging=yes&pr_apres_ski=extensive')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Peak A'}


### PR DESCRIPTION
## Summary
- Adds `has_peak_rankings` boolean filter (based on whether `pr_total` is non-null)
- Adds `pr_total_min`/`pr_total_max` and per-category min/max range params for all 10 PR score dimensions
- Adds `pr_lodging`, `pr_apres_ski`, `pr_access_road`, `pr_ability_low`, `pr_ability_high` multi-value categorical filters (same repeated-param pattern as `region`)
- Adds `pr_total` and `pr_overall_rank` to `ResortSummary` response projection

## Design decisions
- All PR range filters **exclude** resorts with null PR data (consistent with numeric range behavior from #57)
- Categorical filters are case-insensitive
- `has_peak_rankings` explicitly exposes the null check rather than relying on `pr_total_min=1` as a proxy

## Test plan
- [x] `has_peak_rankings=true/false` filters correctly
- [x] `pr_total_min/max` range works; null values excluded
- [x] Per-category range params work independently
- [x] Categorical params work with single and multiple values
- [x] Categorical filter excludes resorts with no PR data
- [x] All params compose with each other and with prior filters
- [x] `pr_total` and `pr_overall_rank` present in response
- [x] All 74 backend tests pass; pipeline tests unaffected; Black clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)