### PR TITLE
Add GET /meta endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI, HTTPException, Query
 from typing import Optional
 
 from data import load_resorts
-from models import Resort, ResortSummary
+from models import Resort, ResortSummary, MetaResponse, RangeField, DateRangeField
 
 _resorts: list[Resort] = []
 
@@ -32,6 +32,40 @@ def _parse_date_list(value: Optional[str]) -> set[str]:
         return set(json.loads(value))
     except (json.JSONDecodeError, TypeError):
         return set()
+
+
+@app.get("/meta", response_model=MetaResponse)
+def get_meta():
+    def _range(field: str) -> RangeField:
+        vals = [v for r in _resorts if (v := getattr(r, field)) is not None]
+        return RangeField(min=min(vals) if vals else None, max=max(vals) if vals else None)
+
+    def _date_range(field: str) -> DateRangeField:
+        dates = {d for r in _resorts for d in _parse_date_list(getattr(r, field))}
+        return DateRangeField(min=min(dates) if dates else None, max=max(dates) if dates else None)
+
+    return MetaResponse(
+        regions=sorted({r.region for r in _resorts if r.region}),
+        countries=sorted({r.country for r in _resorts if r.country}),
+        states=sorted({r.state for r in _resorts if r.state}),
+        vertical=_range('vertical'),
+        num_trails=_range('num_trails'),
+        num_lifts=_range('num_lifts'),
+        trail_length_mi=_range('trail_length_mi'),
+        pr_total=_range('pr_total'),
+        pr_snow=_range('pr_snow'),
+        pr_resiliency=_range('pr_resiliency'),
+        pr_size=_range('pr_size'),
+        pr_terrain_diversity=_range('pr_terrain_diversity'),
+        pr_challenge=_range('pr_challenge'),
+        pr_lifts=_range('pr_lifts'),
+        pr_crowd_flow=_range('pr_crowd_flow'),
+        pr_facilities=_range('pr_facilities'),
+        pr_navigation=_range('pr_navigation'),
+        pr_mountain_aesthetic=_range('pr_mountain_aesthetic'),
+        blackout_date_range=_date_range('blackout_all_dates'),
+        ltt_date_range=_date_range('ltt_blackout_all_dates'),
+    )
 
 
 @app.get("/resorts/{resort_id}", response_model=Resort)

--- a/backend/models.py
+++ b/backend/models.py
@@ -2,6 +2,39 @@ from typing import Optional
 from pydantic import BaseModel
 
 
+class RangeField(BaseModel):
+    min: Optional[float] = None
+    max: Optional[float] = None
+
+
+class DateRangeField(BaseModel):
+    min: Optional[str] = None  # ISO date string YYYY-MM-DD
+    max: Optional[str] = None
+
+
+class MetaResponse(BaseModel):
+    regions: list[str]
+    countries: list[str]
+    states: list[str]
+    vertical: RangeField
+    num_trails: RangeField
+    num_lifts: RangeField
+    trail_length_mi: RangeField
+    pr_total: RangeField
+    pr_snow: RangeField
+    pr_resiliency: RangeField
+    pr_size: RangeField
+    pr_terrain_diversity: RangeField
+    pr_challenge: RangeField
+    pr_lifts: RangeField
+    pr_crowd_flow: RangeField
+    pr_facilities: RangeField
+    pr_navigation: RangeField
+    pr_mountain_aesthetic: RangeField
+    blackout_date_range: DateRangeField
+    ltt_date_range: DateRangeField
+
+
 class ResortSummary(BaseModel):
     """Lean projection returned by GET /resorts — fields needed for the map and table."""
 

--- a/backend/tests/test_meta_endpoint.py
+++ b/backend/tests/test_meta_endpoint.py
@@ -1,0 +1,128 @@
+import sys
+import os
+import json
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from main import app
+from models import Resort
+
+FAKE_RESORTS = [
+    Resort(
+        resort_id='id-1',
+        name='Alpine Resort',
+        region='West',
+        city='Vail',
+        state='CO',
+        country='USA',
+        reservation_status='none',
+        indy_page='https://example.com/alpine',
+        vertical=2000.0,
+        num_trails=100.0,
+        num_lifts=10.0,
+        trail_length_mi=50.0,
+        pr_total=85.0,
+        pr_snow=90.0,
+        pr_resiliency=80.0,
+        pr_size=75.0,
+        pr_terrain_diversity=70.0,
+        pr_challenge=65.0,
+        pr_lifts=60.0,
+        pr_crowd_flow=55.0,
+        pr_facilities=50.0,
+        pr_navigation=45.0,
+        pr_mountain_aesthetic=95.0,
+        blackout_all_dates=json.dumps(['2025-12-25', '2025-12-26']),
+        ltt_blackout_all_dates=json.dumps(['2026-01-01']),
+    ),
+    Resort(
+        resort_id='id-2',
+        name='Nordic Lodge',
+        region='Northeast',
+        city='Stowe',
+        state='VT',
+        country='USA',
+        reservation_status='none',
+        indy_page='https://example.com/nordic',
+        vertical=1000.0,
+        num_trails=50.0,
+        num_lifts=5.0,
+        trail_length_mi=25.0,
+        pr_total=70.0,
+        pr_snow=75.0,
+        pr_resiliency=65.0,
+        pr_size=60.0,
+        pr_terrain_diversity=55.0,
+        pr_challenge=50.0,
+        pr_lifts=45.0,
+        pr_crowd_flow=40.0,
+        pr_facilities=35.0,
+        pr_navigation=30.0,
+        pr_mountain_aesthetic=80.0,
+        blackout_all_dates=json.dumps(['2025-12-24', '2026-01-02']),
+        ltt_blackout_all_dates=json.dumps(['2026-01-15']),
+    ),
+    Resort(
+        resort_id='id-3',
+        name='Tremblant',
+        region='Northeast',
+        city='Mont-Tremblant',
+        state=None,
+        country='Canada',
+        reservation_status='none',
+        indy_page='https://example.com/tremblant',
+        # no numeric fields — tests that nulls are excluded from ranges
+    ),
+]
+
+client = TestClient(app)
+
+
+def test_meta_regions_countries_states():
+    with patch('main._resorts', FAKE_RESORTS):
+        response = client.get('/meta')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['regions'] == ['Northeast', 'West']
+    assert data['countries'] == ['Canada', 'USA']
+    assert data['states'] == ['CO', 'VT']
+
+
+def test_meta_numeric_ranges():
+    with patch('main._resorts', FAKE_RESORTS):
+        response = client.get('/meta')
+    data = response.json()
+    assert data['vertical'] == {'min': 1000.0, 'max': 2000.0}
+    assert data['num_trails'] == {'min': 50.0, 'max': 100.0}
+    assert data['num_lifts'] == {'min': 5.0, 'max': 10.0}
+    assert data['trail_length_mi'] == {'min': 25.0, 'max': 50.0}
+    assert data['pr_total'] == {'min': 70.0, 'max': 85.0}
+
+
+def test_meta_null_values_excluded_from_ranges():
+    with patch('main._resorts', FAKE_RESORTS):
+        response = client.get('/meta')
+    data = response.json()
+    # id-3 has no numeric fields; ranges should still be computed from id-1 and id-2
+    assert data['pr_mountain_aesthetic'] == {'min': 80.0, 'max': 95.0}
+
+
+def test_meta_blackout_date_ranges():
+    with patch('main._resorts', FAKE_RESORTS):
+        response = client.get('/meta')
+    data = response.json()
+    assert data['blackout_date_range'] == {'min': '2025-12-24', 'max': '2026-01-02'}
+    assert data['ltt_date_range'] == {'min': '2026-01-01', 'max': '2026-01-15'}
+
+
+def test_meta_empty_resorts():
+    with patch('main._resorts', []):
+        response = client.get('/meta')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['regions'] == []
+    assert data['vertical'] == {'min': None, 'max': None}
+    assert data['blackout_date_range'] == {'min': None, 'max': None}


### PR DESCRIPTION
## Summary
- Adds `GET /meta` endpoint returning filter boundary data for frontend initialization
- Returns min/max for all numeric range fields (vertical, trails, lifts, trail length, all PR scores)
- Returns sorted lists of available regions, countries, and states
- Returns earliest/latest blackout and LTT dates across the dataset
- Adds `RangeField`, `DateRangeField`, and `MetaResponse` Pydantic models

## Test plan
- [ ] `GET /meta` returns correct min/max for numeric fields
- [ ] Resorts with null values are excluded from range calculations
- [ ] Regions, countries, states are sorted and deduplicated
- [ ] Blackout and LTT date ranges span full dataset
- [ ] Empty resort list returns nulls gracefully
- [ ] All 82 backend tests pass (`cd backend && poetry run pytest`)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)