### PR TITLE
Add API client layer

### DIFF
--- a/frontend/src/api/resorts.js
+++ b/frontend/src/api/resorts.js
@@ -1,0 +1,36 @@
+const BASE = '/api'
+
+function buildQueryString(filters) {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(filters)) {
+    if (value === null || value === undefined) continue
+    if (Array.isArray(value)) {
+      value.forEach(v => params.append(key, v))
+    } else {
+      params.set(key, String(value))
+    }
+  }
+  return params.toString()
+}
+
+async function apiFetch(path) {
+  const res = await fetch(path)
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}))
+    throw new Error(body.detail ?? `Request failed: ${res.status}`)
+  }
+  return res.json()
+}
+
+export async function fetchResorts(filters = {}) {
+  const qs = buildQueryString(filters)
+  return apiFetch(`${BASE}/resorts${qs ? `?${qs}` : ''}`)
+}
+
+export async function fetchResort(id) {
+  return apiFetch(`${BASE}/resorts/${encodeURIComponent(id)}`)
+}
+
+export async function fetchMeta() {
+  return apiFetch(`${BASE}/meta`)
+}


### PR DESCRIPTION
## Summary
- Adds `src/api/resorts.js` with three async functions: `fetchResorts(filters)`, `fetchResort(id)`, `fetchMeta()`
- `buildQueryString` serializes filter objects: arrays become repeated params (`?region=West&region=Northeast`), scalars/booleans use `params.set`
- Non-2xx responses throw an `Error` with the FastAPI `detail` message for easy upstream handling
- No UI — pure data fetching layer for components to build on

## Test plan
- [ ] Production build passes (`npm run build`)
- [ ] `fetchResorts({})` calls `GET /api/resorts` with no query string
- [ ] `fetchResorts({ region: ['West', 'Northeast'], min_vertical: 1000 })` produces correct repeated params
- [ ] `fetchResort(id)` calls `GET /api/resorts/{id}`
- [ ] `fetchMeta()` calls `GET /api/meta`
- [ ] Non-2xx response throws with FastAPI detail message

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)