### PR TITLE
Add location filter sidebar with URL-based filter state

### DIFF
--- a/backend/data.py
+++ b/backend/data.py
@@ -1,3 +1,4 @@
+import math
 import os
 import pandas as pd
 from models import Resort
@@ -8,4 +9,10 @@ RESORTS_CSV = os.path.join(os.path.dirname(__file__), '..', 'data', 'resorts.csv
 def load_resorts() -> list[Resort]:
     df = pd.read_csv(RESORTS_CSV, na_values=[''], keep_default_na=False)
     df = df.where(pd.notna(df), other=None)
-    return [Resort(**row) for row in df.to_dict(orient='records')]
+    records = df.to_dict(orient='records')
+    # pandas represents missing floats as float('nan') after to_dict; convert to None
+    cleaned = [
+        {k: None if isinstance(v, float) and math.isnan(v) else v for k, v in row.items()}
+        for row in records
+    ]
+    return [Resort(**row) for row in cleaned]

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,8 +80,8 @@ def get_resort(resort_id: str):
 def get_resorts(
     search: Optional[str] = Query(default=None),
     region: list[str] = Query(default=[]),
-    country: Optional[str] = Query(default=None),
-    state: Optional[str] = Query(default=None),
+    country: list[str] = Query(default=[]),
+    state: list[str] = Query(default=[]),
     # Boolean feature flags
     has_alpine: Optional[bool] = Query(default=None),
     has_cross_country: Optional[bool] = Query(default=None),
@@ -153,12 +153,12 @@ def get_resorts(
         results = [r for r in results if (r.region or '').lower() in region_set]
 
     if country:
-        c = country.lower()
-        results = [r for r in results if (r.country or '').lower() == c]
+        country_set = {v.lower() for v in country}
+        results = [r for r in results if (r.country or '').lower() in country_set]
 
     if state:
-        s = state.lower()
-        results = [r for r in results if (r.state or '').lower() == s]
+        state_set = {v.lower() for v in state}
+        results = [r for r in results if (r.state or '').lower() in state_set]
 
     # Boolean feature flags
     bool_filters = [

--- a/backend/tests/test_resorts_endpoint.py
+++ b/backend/tests/test_resorts_endpoint.py
@@ -124,12 +124,24 @@ def test_filter_by_country(client):
     assert data[0]['name'] == 'Tremblant'
 
 
+def test_filter_multiple_countries(client):
+    response = client.get('/resorts?country=Canada&country=USA')
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+
+
 def test_filter_by_state(client):
     response = client.get('/resorts?state=CO')
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
     assert data[0]['name'] == 'Vail'
+
+
+def test_filter_multiple_states(client):
+    response = client.get('/resorts?state=CO&state=VT')
+    assert response.status_code == 200
+    assert len(response.json()) == 2
 
 
 def test_combined_filters(client):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,8 @@
         "@fontsource/space-mono": "^5.2.9",
         "antd": "^6.4.2",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "react-router-dom": "^7.15.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -2592,6 +2593,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3776,6 +3790,44 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/react-router": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
+      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.15.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.1.tgz",
+      "integrity": "sha512-AzF62gjY6U9rkMq4RfP/r2EVtQ7DMfNMjyOp/flLTCrtRylLiK4wT4pSq6O8rOXZ2eXdZYJPEYe+ifomiv+Igg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.15.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3851,6 +3903,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "@fontsource/space-mono": "^5.2.9",
     "antd": "^6.4.2",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "react-router-dom": "^7.15.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,8 @@
+import { useEffect, useState } from 'react'
 import { ConfigProvider, Layout, theme as antdTheme } from 'antd'
+import { useSearchParams } from 'react-router-dom'
+import { useFilters } from '@/hooks/useFilters'
+import { fetchResorts, fetchMeta } from '@/api/resorts'
 import AppHeader from '@/components/layout/Header'
 import AppSidebar from '@/components/layout/Sidebar'
 import AppFooter from '@/components/layout/Footer'
@@ -25,12 +29,41 @@ const themeConfig = {
 }
 
 export default function App() {
+  const [searchParams] = useSearchParams()
+  const { filters } = useFilters()
+
+  const [resorts, setResorts] = useState([])
+  const [allResorts, setAllResorts] = useState([])
+  const [meta, setMeta] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  // Fetch meta and full unfiltered resort list once on mount
+  useEffect(() => {
+    fetchMeta()
+      .then(setMeta)
+      .catch(e => console.error('Failed to load meta:', e))
+    fetchResorts({})
+      .then(setAllResorts)
+      .catch(e => console.error('Failed to load all resorts:', e))
+  }, [])
+
+  // Fetch resorts whenever filters change
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    fetchResorts(filters)
+      .then(setResorts)
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [searchParams.toString()])
+
   return (
     <ConfigProvider theme={themeConfig}>
       <Layout style={{ height: '100%' }}>
         <AppHeader />
         <Layout>
-          <AppSidebar />
+          <AppSidebar meta={meta} allResorts={allResorts} />
           <Layout>
             <Layout.Content style={{ overflow: 'auto', padding: 24 }}>
               <div style={{ height: 200, background: '#f0f0f0', borderRadius: 4, marginBottom: 16 }} />

--- a/frontend/src/components/filters/LocationFilters.jsx
+++ b/frontend/src/components/filters/LocationFilters.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react'
+import { Select, Typography } from 'antd'
+import { useFilters } from '@/hooks/useFilters'
+
+function toOptions(values) {
+  return values.map(v => ({ label: v, value: v }))
+}
+
+function unique(arr) {
+  return [...new Set(arr.filter(Boolean))].sort()
+}
+
+function useDeferredFilter(urlValue, filterKey) {
+  const { setFilter } = useFilters()
+  const [local, setLocal] = useState(urlValue)
+  const ref = useRef(urlValue)
+
+  useEffect(() => {
+    setLocal(urlValue)
+    ref.current = urlValue
+  }, [JSON.stringify(urlValue)])
+
+  function onChange(v) {
+    setLocal(v)
+    ref.current = v
+  }
+
+  function onOpenChange(open) {
+    if (!open) setFilter(filterKey, ref.current)
+  }
+
+  return { local, onChange, onOpenChange }
+}
+
+export default function LocationFilters({ meta, allResorts }) {
+  const { filters } = useFilters()
+
+  // Options cascade using committed filter values, but each field ignores its own filter
+  const regionOptions = toOptions(meta?.regions ?? [])
+
+  const countryOptions = toOptions(unique(
+    allResorts
+      .filter(r => filters.region.length === 0 || filters.region.includes(r.region))
+      .map(r => r.country)
+  ))
+
+  const stateOptions = toOptions(unique(
+    allResorts
+      .filter(r => filters.region.length === 0 || filters.region.includes(r.region))
+      .filter(r => filters.country.length === 0 || filters.country.includes(r.country))
+      .map(r => r.state)
+  ))
+
+  const region = useDeferredFilter(filters.region, 'region')
+  const country = useDeferredFilter(filters.country, 'country')
+  const state = useDeferredFilter(filters.state, 'state')
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <Typography.Text
+        type="secondary"
+        style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+      >
+        Location
+      </Typography.Text>
+
+      <Select
+        mode="multiple"
+        allowClear
+        placeholder="All regions"
+        options={regionOptions}
+        value={region.local}
+        onChange={region.onChange}
+        onOpenChange={region.onOpenChange}
+        style={{ width: '100%' }}
+      />
+
+      <Select
+        mode="multiple"
+        allowClear
+        placeholder="All countries"
+        options={countryOptions}
+        value={country.local}
+        onChange={country.onChange}
+        onOpenChange={country.onOpenChange}
+        style={{ width: '100%' }}
+      />
+
+      <Select
+        mode="multiple"
+        allowClear
+        placeholder="All states / provinces"
+        options={stateOptions}
+        value={state.local}
+        onChange={state.onChange}
+        onOpenChange={state.onOpenChange}
+        style={{ width: '100%' }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,6 +1,7 @@
-import { Layout, Typography } from 'antd'
+import { Layout } from 'antd'
+import LocationFilters from '@/components/filters/LocationFilters'
 
-export default function AppSidebar() {
+export default function AppSidebar({ meta, allResorts }) {
   return (
     <Layout.Sider
       breakpoint="md"
@@ -12,18 +13,8 @@ export default function AppSidebar() {
         overflow: 'auto',
       }}
     >
-      <div style={{ padding: 16 }}>
-        <Typography.Text
-          type="secondary"
-          style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em' }}
-        >
-          Filters
-        </Typography.Text>
-        <div style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 12 }}>
-          {[...Array(5)].map((_, i) => (
-            <div key={i} style={{ height: 32, borderRadius: 2, background: '#e8e8e8' }} />
-          ))}
-        </div>
+      <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <LocationFilters meta={meta} allResorts={allResorts ?? []} />
       </div>
     </Layout.Sider>
   )

--- a/frontend/src/hooks/useFilters.js
+++ b/frontend/src/hooks/useFilters.js
@@ -1,0 +1,60 @@
+import { useSearchParams } from 'react-router-dom'
+import { useCallback } from 'react'
+
+export function useFilters() {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const filters = {
+    // Location
+    region: searchParams.getAll('region'),
+    country: searchParams.getAll('country'),
+    state: searchParams.getAll('state'),
+    // Feature filters, range filters, date filters added in subsequent issues
+  }
+
+  function applyUpdates(next, updates) {
+    for (const [key, value] of Object.entries(updates)) {
+      const isEmpty =
+        value === null ||
+        value === undefined ||
+        value === '' ||
+        (Array.isArray(value) && value.length === 0)
+      if (isEmpty) {
+        next.delete(key)
+      } else if (Array.isArray(value)) {
+        next.delete(key)
+        value.forEach(v => next.append(key, v))
+      } else {
+        next.set(key, String(value))
+      }
+    }
+  }
+
+  const setFilter = useCallback(
+    (key, value) => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev)
+        applyUpdates(next, { [key]: value })
+        return next
+      })
+    },
+    [setSearchParams]
+  )
+
+  const setFilters = useCallback(
+    (updates) => {
+      setSearchParams(prev => {
+        const next = new URLSearchParams(prev)
+        applyUpdates(next, updates)
+        return next
+      })
+    },
+    [setSearchParams]
+  )
+
+  const resetFilters = useCallback(() => {
+    setSearchParams(new URLSearchParams())
+  }, [setSearchParams])
+
+  return { filters, setFilter, setFilters, resetFilters }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Adds Region, Country, State multi-select dropdowns to the sidebar
- Filter state lives in URL query params via `react-router-dom` — filters survive refresh, back button works, and filter sets are shareable as links
- `useFilters` hook centralises all URL param read/write with atomic multi-param updates
- `useDeferredFilter` buffers selections locally and commits to URL only on dropdown close, so options stay stable while the user is mid-selection
- Cascading options: country narrows by selected regions; state narrows by selected regions + countries — each field ignores its own committed value so multi-select never collapses its own options

## Bug fixes included
- **Backend 500 on `GET /resorts`**: `float('nan')` values from pandas `to_dict()` now converted to `None` before Pydantic construction
- **`country` and `state` params**: upgraded to multi-value (`list[str]`) consistent with `region`; filter logic and tests updated

## Test plan
- [ ] Selecting regions narrows country options; selecting countries narrows state options
- [ ] Multi-select works freely within each dropdown — options don't change until dropdown closes
- [ ] Active filters reflected in URL (e.g. `?region=West&country=USA`)
- [ ] Refreshing page preserves filter state
- [ ] Clearing all selections resets results
- [ ] 84 backend tests pass (`cd backend && poetry run pytest`)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)