### PR TITLE
add resort feature filters with range sliders and boolean toggles (#65)

### DIFF
--- a/frontend/src/components/filters/ResortFeatureFilters.jsx
+++ b/frontend/src/components/filters/ResortFeatureFilters.jsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react'
+import { Button, Slider, Typography } from 'antd'
+import { useFilters } from '@/hooks/useFilters'
+
+const { Text } = Typography
+
+function SectionLabel({ children }) {
+  return (
+    <Text
+      type="secondary"
+      style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em' }}
+    >
+      {children}
+    </Text>
+  )
+}
+
+function RangeSlider({ label, metaRange, minKey, maxKey }) {
+  const { filters, setFilters } = useFilters()
+
+  const metaMin = Math.floor(metaRange?.min ?? 0)
+  const metaMax = Math.ceil(metaRange?.max ?? 100)
+
+  const urlMin = filters[minKey] ?? metaMin
+  const urlMax = filters[maxKey] ?? metaMax
+
+  const [local, setLocal] = useState([urlMin, urlMax])
+
+  // Sync when URL changes (back/forward) or meta loads
+  useEffect(() => {
+    setLocal([filters[minKey] ?? metaMin, filters[maxKey] ?? metaMax])
+  }, [filters[minKey], filters[maxKey], metaMin, metaMax])
+
+  function onChangeComplete([min, max]) {
+    setFilters({
+      [minKey]: min === metaMin ? null : min,
+      [maxKey]: max === metaMax ? null : max,
+    })
+  }
+
+  const atDefault = local[0] === metaMin && local[1] === metaMax
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 2 }}>
+        <Text style={{ fontSize: 12 }}>{label}</Text>
+        {!atDefault && (
+          <Text type="secondary" style={{ fontSize: 11 }}>
+            {local[0].toLocaleString()} – {local[1].toLocaleString()}
+          </Text>
+        )}
+      </div>
+      <Slider
+        range
+        min={metaMin}
+        max={metaMax}
+        value={local}
+        onChange={setLocal}
+        onChangeComplete={onChangeComplete}
+        disabled={metaRange === null}
+        tooltip={{ formatter: v => v.toLocaleString() }}
+      />
+    </div>
+  )
+}
+
+function FeatureToggle({ label, filterKey }) {
+  const { filters, setFilter } = useFilters()
+  const current = filters[filterKey]
+  const yesActive = current === undefined || current === true
+  const noActive  = current === undefined || current === false
+
+  function toggleYes() {
+    if (current === true) setFilter(filterKey, null)   // yes → both (clear param)
+    else                  setFilter(filterKey, true)   // both or no → yes only
+  }
+
+  function toggleNo() {
+    if (current === false) setFilter(filterKey, null)  // no → both (clear param)
+    else                   setFilter(filterKey, false) // both or yes → no only
+  }
+
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+      <Text style={{ fontSize: 12, flex: 1 }}>{label}</Text>
+      <Button.Group size="small">
+        <Button type={yesActive ? 'primary' : 'default'} onClick={toggleYes}>Yes</Button>
+        <Button type={noActive  ? 'primary' : 'default'} onClick={toggleNo}>No</Button>
+      </Button.Group>
+    </div>
+  )
+}
+
+const BOOLEAN_FILTERS = [
+  { label: 'Alpine skiing',       key: 'has_alpine' },
+  { label: 'Cross-country',       key: 'has_cross_country' },
+  { label: 'Night skiing',        key: 'has_night_skiing' },
+  { label: 'Terrain parks',       key: 'has_terrain_parks' },
+  { label: 'Dog friendly',        key: 'is_dog_friendly' },
+  { label: 'Snowshoeing',         key: 'has_snowshoeing' },
+  { label: 'Allied resort',       key: 'is_allied' },
+  { label: 'Reservation required', key: 'reservation_required' },
+]
+
+export default function ResortFeatureFilters({ meta }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <SectionLabel>Stats</SectionLabel>
+
+      <RangeSlider
+        label="Vertical (ft)"
+        metaRange={meta?.vertical ?? null}
+        minKey="min_vertical"
+        maxKey="max_vertical"
+      />
+      <RangeSlider
+        label="Trails"
+        metaRange={meta?.num_trails ?? null}
+        minKey="min_trails"
+        maxKey="max_trails"
+      />
+      <RangeSlider
+        label="Lifts"
+        metaRange={meta?.num_lifts ?? null}
+        minKey="min_lifts"
+        maxKey="max_lifts"
+      />
+      <RangeSlider
+        label="Trail length (mi)"
+        metaRange={meta?.trail_length_mi ?? null}
+        minKey="min_trail_length"
+        maxKey="max_trail_length"
+      />
+
+      <SectionLabel style={{ marginTop: 8 }}>Features</SectionLabel>
+
+      {BOOLEAN_FILTERS.map(({ label, key }) => (
+        <FeatureToggle key={key} label={label} filterKey={key} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,5 +1,6 @@
-import { Layout } from 'antd'
+import { Divider, Layout } from 'antd'
 import LocationFilters from '@/components/filters/LocationFilters'
+import ResortFeatureFilters from '@/components/filters/ResortFeatureFilters'
 
 export default function AppSidebar({ meta, allResorts }) {
   return (
@@ -15,6 +16,8 @@ export default function AppSidebar({ meta, allResorts }) {
     >
       <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 24 }}>
         <LocationFilters meta={meta} allResorts={allResorts ?? []} />
+        <Divider style={{ margin: 0 }} />
+        <ResortFeatureFilters meta={meta} />
       </div>
     </Layout.Sider>
   )

--- a/frontend/src/hooks/useFilters.js
+++ b/frontend/src/hooks/useFilters.js
@@ -4,12 +4,41 @@ import { useCallback } from 'react'
 export function useFilters() {
   const [searchParams, setSearchParams] = useSearchParams()
 
+  function getNum(key) {
+    const v = searchParams.get(key)
+    return v !== null ? Number(v) : undefined
+  }
+
+  function getBool(key) {
+    const v = searchParams.get(key)
+    if (v === 'true') return true    // yes only
+    if (v === 'false') return false  // no only
+    return undefined                 // absent = both active = no filter
+  }
+
   const filters = {
     // Location
     region: searchParams.getAll('region'),
     country: searchParams.getAll('country'),
     state: searchParams.getAll('state'),
-    // Feature filters, range filters, date filters added in subsequent issues
+    // Numeric range filters
+    min_vertical: getNum('min_vertical'),
+    max_vertical: getNum('max_vertical'),
+    min_trails: getNum('min_trails'),
+    max_trails: getNum('max_trails'),
+    min_lifts: getNum('min_lifts'),
+    max_lifts: getNum('max_lifts'),
+    min_trail_length: getNum('min_trail_length'),
+    max_trail_length: getNum('max_trail_length'),
+    // Boolean feature toggles
+    has_alpine: getBool('has_alpine'),
+    has_cross_country: getBool('has_cross_country'),
+    has_night_skiing: getBool('has_night_skiing'),
+    has_terrain_parks: getBool('has_terrain_parks'),
+    is_dog_friendly: getBool('is_dog_friendly'),
+    has_snowshoeing: getBool('has_snowshoeing'),
+    is_allied: getBool('is_allied'),
+    reservation_required: getBool('reservation_required'),
   }
 
   function applyUpdates(next, updates) {


### PR DESCRIPTION
## Summary
- Adds `ResortFeatureFilters` component with `RangeSlider` (vertical, trails, lifts, trail length) and `FeatureToggle` (8 boolean features)
- Extends `useFilters` hook with `getNum`/`getBool` helpers and all new filter keys
- Toggles are 3-state: both lit = no filter (default), yes-only, no-only — clicking the active button resets to both
- Range sliders commit to URL on drag-complete; local state buffers mid-drag values
- Wires up `ResortFeatureFilters` in the sidebar with a divider below location filters

## Test plan
- [ ] Range sliders update URL params on release and filter resorts correctly
- [ ] Boolean toggles cycle: both → yes-only → both, both → no-only → both, yes → no-only, no → yes-only
- [ ] Absent URL param = both buttons lit (no filter applied)
- [ ] Reset filters clears all range and boolean params
- [ ] Back/forward navigation restores slider and toggle state

🤖 Generated with [Claude Code](https://claude.com/claude-code)