### PR TITLE
Deploy backend to Fly.io and frontend to Vercel (#100)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Allowlist: exclude everything, then explicitly re-include what the backend needs.
+# The backend image only needs the Python app (backend/) and the data CSVs (data/).
+
+*
+
+!backend/
+!data/
+
+# Exclude within the allowed directories
+data/resort_page_extracts/
+**/__pycache__/
+**/*.pyc
+**/*.pyo

--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,9 @@ dist/
 # Planning / design docs
 planning/
 
+# Personal ops runbook
+docs/ops-runbook.md
+
 # AI coding assistants
 .claude/
 .cursor/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,30 @@ The aesthetic direction, dark mode token config, glow effects, and open design q
 
 Settled architectural and design decisions are documented in [`docs/decisions.md`](docs/decisions.md). Do not relitigate them without checking with the user. When completing any non-trivial task, append a new entry there — see the format specified in that file.
 
+## Ops Runbook
+
+A personal ops runbook lives at `docs/ops-runbook.md` (git-ignored; the user keeps a copy outside the repo). It covers:
+
+- Backend deploy commands (Fly.io) and how to verify a deploy
+- Frontend deploy (Vercel) and required env vars
+- Pipeline run commands and the backup/restore procedure
+- Secrets and credentials inventory
+- Common troubleshooting scenarios
+
+**When ops practices change** (new deploy steps, new secrets, new services, architecture changes), update `docs/ops-runbook.md` to match. If the file is missing (user hasn't placed it yet), note the relevant change so the user can add it manually.
+
 ## Environment & Secrets
 
-- `GOOGLE_MAPS_API_KEY` in `.env` — for geocoding (quota-sensitive; prefer cached `data/resort_locations.csv`). In production: `flyctl secrets set GOOGLE_MAPS_API_KEY=...`
+- `GOOGLE_MAPS_API_KEY` in `.env` — for geocoding (quota-sensitive; prefer cached `data/resort_locations.csv`). Not needed by the backend at runtime — pipeline only.
 - `MAPBOX_TOKEN` in `.streamlit/secrets.toml` — for map rendering in Streamlit
 - `VITE_MAPBOX_TOKEN` — for map rendering in the React frontend. Set in Vercel dashboard (build-time env var; `VITE_` prefix required for browser exposure)
+
+## Deployed Services
+
+- **Backend:** `https://indy-explorer-backend.fly.dev` (Fly.io, region: ewr)
+  - Deploy from repo root: `flyctl deploy --config backend/fly.toml`
+  - Docker image bakes in `data/` at build time — redeploy after pipeline data updates
+- **Frontend:** Vercel (URL TBD — update this once deployed)
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -111,33 +111,7 @@ GitHub Actions runs tests and Black checks on push/PRs. Coverage is optionally u
 
 ## Deployment
 
-The React frontend is hosted on Vercel and the FastAPI backend on Fly.io.
-
-### Frontend (Vercel)
-
-Vercel deploys automatically on push to `main` via GitHub integration.
-
-1. Install the Vercel CLI: `npm install -g vercel`
-2. Link the project: `cd frontend && vercel link`
-3. Set the Mapbox token as an environment variable in the Vercel dashboard:
-   - Key: `VITE_MAPBOX_TOKEN`
-   - Value: your Mapbox token
-   - Environment: Production (and Preview if desired)
-4. Deploy manually if needed: `vercel --prod`
-
-### Backend (Fly.io)
-
-1. Install the Fly CLI: `brew install flyctl`
-2. Authenticate: `flyctl auth login`
-3. Create the app (first time only): `cd backend && flyctl launch --no-deploy`
-4. Set secrets:
-   ```sh
-   flyctl secrets set GOOGLE_MAPS_API_KEY=your_key_here
-   ```
-5. Deploy: `flyctl deploy`
-6. Check health: `curl https://indy-explorer-backend.fly.dev/health`
-
-Subsequent deploys run automatically on push to `main` via the CI/CD pipeline (to be configured in a later issue).
+The FastAPI backend is hosted on [Fly.io](https://fly.io) and the React frontend on [Vercel](https://vercel.com). The frontend proxies all `/api/*` requests to the backend — no CORS configuration needed.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,7 @@ The app ships with pre-built data in `data/resorts.csv` — no pipeline run need
 
 The pipeline orchestrator handles scraping, geocoding, blackout dates, rankings, and merging.
 
-### Before refreshing: back up existing data
-
-```sh
-cp -r cache/ backups/cache_backup_$(date +%Y%m%d_%H%M%S)
-cp -r data/ backups/data_backup_$(date +%Y%m%d_%H%M%S)
-```
+The pipeline automatically backs up `data/resorts.csv`, `data/resort_id_map.csv`, and `data/pipeline_metadata.json` to a timestamped directory under `backups/` before any steps run. The 10 most recent backups are kept; older ones are deleted. To restore, copy the desired files back to `data/`.
 
 ```sh
 # Incremental refresh (uses cached HTML, fetches new resorts only)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,10 +5,13 @@ WORKDIR /app
 RUN pip install --no-cache-dir poetry==2.1.3 && \
     poetry config virtualenvs.create false
 
-COPY pyproject.toml poetry.lock ./
+# Copy dependency files first for layer caching
+COPY backend/pyproject.toml backend/poetry.lock ./
 RUN poetry install --only main --no-interaction
 
-COPY . .
+# Copy backend source and data (built from repo root)
+COPY backend/ .
+COPY data/ /data/
 
 EXPOSE 8000
 

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -2,7 +2,7 @@ app = "indy-explorer-backend"
 primary_region = "ewr"
 
 [build]
-  dockerfile = "backend/Dockerfile"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 8000

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,5 +1,5 @@
 app = "indy-explorer-backend"
-primary_region = "iad"
+primary_region = "ewr"
 
 [build]
   dockerfile = "backend/Dockerfile"

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -2,6 +2,7 @@ app = "indy-explorer-backend"
 primary_region = "iad"
 
 [build]
+  dockerfile = "backend/Dockerfile"
 
 [http_service]
   internal_port = 8000

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -101,3 +101,10 @@ Format for new entries:
 **Decision:** All color values in `frontend/src/` must reference named tokens from `COLORS` in `src/theme.js`. No hardcoded hex or rgba strings in `.jsx` or `.css` files. CSS files bridge to theme values via CSS custom properties set in `GRID_THEME_VARS` (e.g. `--indy-header-bg`). The `withAlpha(hex, alpha)` utility generates rgba strings from theme hex values.  
 **Rationale:** One audit found `COLORS.accent` (undefined), two unique greens, and three similar greys scattered across components. Centralizing prevents drift and makes visual changes a single-file edit.  
 **Follow-up:** When adding new colors, add to `COLORS` in theme.js first, then reference by name.
+
+---
+## 2026-05-24 — Deployment: Fly.io + Vercel split
+**Issue:** #100  
+**Decision:** Backend on Fly.io (`indy-explorer-backend`, region `ewr`), frontend on Vercel. Frontend proxies `/api/:path*` → `https://indy-explorer-backend.fly.dev/:path*` via `vercel.json` rewrite — no CORS config needed. Docker image built from repo root so `data/` is baked in at deploy time (not read from a volume).  
+**Rationale:** Vercel is purpose-built for static SPAs (CDN, zero-config GitHub auto-deploy). Fly.io handles the containerized FastAPI. All-Fly.io was considered but requires nginx and has no global CDN equivalent. Baking `data/` into the image keeps the backend stateless and dead-simple to deploy; after a pipeline data update, redeploy the backend.  
+**Follow-up:** After a pipeline data update, both `data/resorts.csv` must be committed to main AND the backend must be redeployed (`flyctl deploy --config backend/fly.toml`) for new data to appear in the live app.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -6,9 +6,9 @@ Current work-in-progress. Update this file at the start and end of every session
 
 ## Current Branch
 
-`main` (no active feature branch)
+`feature/100-deploy-fly-vercel` — deployment config; PR open, pending merge + Vercel setup
 
-## Status (as of 2026-05-23)
+## Status (as of 2026-05-24)
 
 ### React rewrite — feature complete
 
@@ -20,18 +20,24 @@ All user-facing work is merged to main:
 - **#72–#75** Resort data table (AG Grid), detail modal, charts, Peak Rankings section
 - **#70** Map tooltip smart positioning — merged with #72–#75 branch
 
+### Deployment — in progress (#100)
+
+- **Backend (Fly.io):** Live at `https://indy-explorer-backend.fly.dev` ✓
+- **Frontend (Vercel):** Pending — merge #100 branch first, then create Vercel project pointing to `main`
+
 ### Remaining open
 
 | # | Description | Type | Notes |
 |---|---|---|---|
 | #76 | Pipeline output compatibility | Infrastructure | **Done** ✓ |
+| #100 | Deploy backend to Fly.io + frontend to Vercel | Infrastructure | Backend live ✓; frontend pending Vercel setup |
 | #83 | Data validation on Resort Pydantic model | Backend hardening | Must be done before #77 |
 | #77 | GitHub Actions scheduled pipeline | Infrastructure | Depends on #83; revised to PR-based data promotion (no auto-commit to main) |
 | #11 | Bug: metrics parsing for alpine+XC resorts | Pre-rewrite bug | |
 | #21 | Include all resorts, filter down to Indy | Future enhancement | |
 | #22 | Add RV parking data/filter | Future enhancement | |
 
-**Next up:** Deploy backend to Fly.io + frontend to Vercel → #83 → #77.
+**Next up:** Merge #100 → finish Vercel setup → #83 → #77.
 
 **#77 revised scope:** Pipeline runs on a schedule and opens a PR against main rather than auto-committing. Human reviews the data diff before merging. Pre-PR sanity check runs `load_resorts()` against the new CSV — any Pydantic validation failures abort the job before a PR is opened. See issue for full acceptance criteria.
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,6 +2,7 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
+    { "source": "/api/:path*", "destination": "https://indy-explorer-backend.fly.dev/:path*" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary

- Docker image updated to build from repo root so `data/` is baked in at deploy time
- `fly.toml` configured with correct dockerfile path and `ewr` region; deploy with `flyctl deploy --config backend/fly.toml` from repo root
- `.dockerignore` allowlist: only `backend/` and `data/` sent to the Docker builder
- `vercel.json` proxies `/api/:path*` → `https://indy-explorer-backend.fly.dev/:path*` (no CORS needed)
- Backend is already live: https://indy-explorer-backend.fly.dev/health

## Status

- [x] Backend deployed and healthy
- [ ] Frontend — set up Vercel project after this merges (root dir: `frontend`, env var: `VITE_MAPBOX_TOKEN`)

## Test plan

- [ ] `curl https://indy-explorer-backend.fly.dev/health` → `{"status":"ok"}`
- [ ] `curl https://indy-explorer-backend.fly.dev/resorts?search=stowe` returns resort data
- [ ] After Vercel deploy: frontend loads and map/table populate from live backend

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)