### PR TITLE
Mobile P0s: collapsible sidebar, last updated date, toolbar/footer layout (#103, #104, #105)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -61,6 +61,13 @@ Format for new entries:
 **Follow-up:** Implement before Issues #14–#18. Ensure filter params are kept clean and human-readable (e.g., `?pass=ikon&region=northeast`).
 
 ---
+## 2026-05-25 — Mobile sidebar: Drawer overlay pattern
+**Issue:** #103, #105
+**Decision:** On mobile (< 768px), `AppSidebar` renders as an Ant Design `Drawer` overlay instead of a `Layout.Sider` push column. Desktop keeps the push layout with drag-to-resize. The `isMobile` flag is set on mount and updated on resize. The Drawer is `closable={false}`; the close affordance is a double-chevron SVG in the content header row. The same chevron (in the app header) toggles both desktop and mobile.
+**Rationale:** A layout column on mobile squeezed the content area to ~80px, making the footer and table unusable. Overlay keeps content full-width. Ant Design `Drawer` handles the backdrop, animation, and scroll-lock.
+**Follow-up:** Touch drag-to-resize on desktop sidebar not implemented (nice-to-have).
+
+---
 ## 2026-05-22 — Resort detail modal and blackout calendar
 **Issue:** #73  
 **Decision:** Resort detail opens in an antd `Modal` (600px wide). Blackout dates render in an antd `Calendar` with `fullCellRender` — colored circles over each date (standard=magenta, LTT=cyan, both=diagonal split gradient). Today gets a border ring only (transparent fill so blackout color shows through). Out-of-month dates fade to 10% opacity. Month state persists across modal opens via a module-level variable (`sharedCalendarMonth`) that survives `destroyOnClose` unmounting. All three navigation paths (dropdowns, prev/next buttons, clicking an out-of-month date) route through the same `setMonth()` setter, which also updates the shared variable.  

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -27,7 +27,7 @@ Target: public launch on Indy Pass Facebook groups ahead of ski season.
 |---|---|---|---|
 | #103 | Mobile: filter sidebar inaccessible | P0 | Done |
 | #104 | Bug: "Last updated" not populating | P0 | Done |
-| #105 | Mobile: toolbar and footer layout broken | P0 | |
+| #105 | Mobile: toolbar and footer layout broken | P0 | Done |
 | #106 | Cold start: keep Fly.io machine warm | P1 | |
 | #83 | Data validation on Resort Pydantic model | P1 | Blocks #77 |
 | #77 | GitHub Actions scheduled pipeline | P1 | Depends on #83 |

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -25,8 +25,8 @@ Target: public launch on Indy Pass Facebook groups ahead of ski season.
 
 | # | Description | Priority | Status |
 |---|---|---|---|
-| #103 | Mobile: filter sidebar inaccessible | P0 | |
-| #104 | Bug: "Last updated" not populating | P0 | |
+| #103 | Mobile: filter sidebar inaccessible | P0 | Done |
+| #104 | Bug: "Last updated" not populating | P0 | Done |
 | #105 | Mobile: toolbar and footer layout broken | P0 | |
 | #106 | Cold start: keep Fly.io machine warm | P1 | |
 | #83 | Data validation on Resort Pydantic model | P1 | Blocks #77 |

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -6,7 +6,7 @@ Current work-in-progress. Update this file at the start and end of every session
 
 ## Current Branch
 
-`main` (no active feature branch)
+`feature/103-104-105-mobile-layout` — mobile P0s: filter sidebar (#103), last updated date (#104), toolbar/footer layout (#105)
 
 ## Status (as of 2026-05-24)
 
@@ -26,8 +26,8 @@ Target: public launch on Indy Pass Facebook groups ahead of ski season.
 | # | Description | Priority | Status |
 |---|---|---|---|
 | #103 | Mobile: filter sidebar inaccessible | P0 | |
-| #104 | Mobile: toolbar and footer layout | P0 | |
-| #105 | Bug: "Last updated" not populating | P1 | |
+| #104 | Bug: "Last updated" not populating | P0 | |
+| #105 | Mobile: toolbar and footer layout broken | P0 | |
 | #106 | Cold start: keep Fly.io machine warm | P1 | |
 | #83 | Data validation on Resort Pydantic model | P1 | Blocks #77 |
 | #77 | GitHub Actions scheduled pipeline | P1 | Depends on #83 |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,9 @@ export default function App() {
   const [error, setError] = useState(null)
   const [selectedResortId, setSelectedResortId] = useState(null)
 
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => window.innerWidth < 768)
+  const [sidebarWidth, setSidebarWidth] = useState(280)
+
   const [tableHeight, setTableHeight] = useState(DEFAULT_TABLE_HEIGHT)
   const [tableCollapsed, setTableCollapsed] = useState(false)
 
@@ -110,6 +113,21 @@ export default function App() {
     </div>
   )
 
+  function startSidebarDrag(e) {
+    e.preventDefault()
+    const startX = e.clientX
+    const startW = sidebarWidth
+    function onMove(ev) {
+      setSidebarWidth(Math.max(200, Math.min(480, startW + (ev.clientX - startX))))
+    }
+    function onUp() {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }
+
   function startDrag(e) {
     e.preventDefault()
     const startY = e.clientY
@@ -130,9 +148,26 @@ export default function App() {
   return (
     <ConfigProvider theme={themeConfig}>
       <Layout style={{ height: '100%' }}>
-        <AppHeader />
+        <AppHeader sidebarCollapsed={sidebarCollapsed} onToggleSidebar={() => setSidebarCollapsed(c => !c)} />
         <Layout>
-          <AppSidebar meta={meta} allResorts={allResorts} />
+          <AppSidebar
+            meta={meta}
+            allResorts={allResorts}
+            collapsed={sidebarCollapsed}
+            width={sidebarWidth}
+          />
+          {!sidebarCollapsed && (
+            <div
+              onMouseDown={startSidebarDrag}
+              style={{
+                width: 4,
+                flexShrink: 0,
+                cursor: 'ew-resize',
+                background: COLORS.border,
+                zIndex: 1,
+              }}
+            />
+          )}
           <Layout>
             <Layout.Content style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
               <div style={{ padding: '12px 24px' }}>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -234,7 +234,7 @@ export default function App() {
                 )}
               </div>
             </Layout.Content>
-            <AppFooter />
+            <AppFooter lastUpdated={meta?.last_pipeline_run ? new Date(meta.last_pipeline_run).toLocaleDateString() : null} />
           </Layout>
         </Layout>
       </Layout>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,8 +27,15 @@ export default function App() {
   const [error, setError] = useState(null)
   const [selectedResortId, setSelectedResortId] = useState(null)
 
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => window.innerWidth < 768)
   const [sidebarWidth, setSidebarWidth] = useState(280)
+
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < 768)
+    window.addEventListener('resize', handler)
+    return () => window.removeEventListener('resize', handler)
+  }, [])
 
   const [tableHeight, setTableHeight] = useState(DEFAULT_TABLE_HEIGHT)
   const [tableCollapsed, setTableCollapsed] = useState(false)
@@ -155,8 +162,10 @@ export default function App() {
             allResorts={allResorts}
             collapsed={sidebarCollapsed}
             width={sidebarWidth}
+            isMobile={isMobile}
+            onClose={() => setSidebarCollapsed(true)}
           />
-          {!sidebarCollapsed && (
+          {!isMobile && !sidebarCollapsed && (
             <div
               onMouseDown={startSidebarDrag}
               style={{
@@ -186,13 +195,15 @@ export default function App() {
                 <div
                   onMouseDown={tableCollapsed ? undefined : startDrag}
                   style={{
-                    height: 28,
+                    minHeight: 28,
                     background: COLORS.bgLayout,
                     borderTop: `1px solid ${COLORS.border}`,
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-between',
-                    padding: '0 16px',
+                    flexWrap: 'wrap',
+                    rowGap: 4,
+                    padding: '4px 16px',
                     cursor: tableCollapsed ? 'default' : 'ns-resize',
                     userSelect: 'none',
                   }}

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -11,6 +11,8 @@ export default function AppFooter({ lastUpdated }) {
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: '4px 16px',
       }}
     >
       <Typography.Text type="secondary" style={{ fontSize: 12 }}>

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -20,8 +20,8 @@ export default function AppFooter({ lastUpdated }) {
         <Typography.Link style={{ color: token.colorError }} href="https://www.indyskipass.com" target="_blank">Indy Pass</Typography.Link>
         {', '}
         <Typography.Link style={{ color: token.colorError }} href="https://peakrankings.com" target="_blank">Peak Rankings</Typography.Link>
-        {', and the '}
-        <Typography.Link style={{ color: token.colorError }} href="https://developers.google.com/maps/documentation/geocoding" target="_blank">Google Maps Geocoding API</Typography.Link>
+        {', and '}
+        <Typography.Link style={{ color: token.colorError }} href="https://developers.google.com/maps/documentation/geocoding" target="_blank">Google Maps</Typography.Link>
       </Typography.Text>
       <Typography.Text type="secondary" style={{ fontSize: 12 }}>
         Last updated: {lastUpdated ?? '—'}

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -1,13 +1,14 @@
-import { Layout, Typography, theme } from 'antd'
-import { FONTS } from '@/theme'
+import { Button, Divider, Layout, Typography, theme } from 'antd'
+import { COLORS, FONTS } from '@/theme'
 
-export default function AppHeader() {
+export default function AppHeader({ sidebarCollapsed, onToggleSidebar }) {
   const { token } = theme.useToken()
   return (
     <Layout.Header
       style={{
         display: 'flex',
         alignItems: 'center',
+        gap: 12,
         background: token.colorBgContainer,
         borderBottom: `1px solid ${token.colorBorder}`,
         padding: '0 24px',
@@ -15,6 +16,23 @@ export default function AppHeader() {
         lineHeight: '56px',
       }}
     >
+      <Button
+        type="text"
+        onClick={onToggleSidebar}
+        aria-label={sidebarCollapsed ? 'Expand filters' : 'Collapse filters'}
+        style={{ color: COLORS.error, padding: '0 6px', flexShrink: 0, lineHeight: 1, display: 'flex', alignItems: 'center' }}
+      >
+        <svg width="16" height="12" viewBox="0 0 16 12" fill="none" style={{ display: 'block', transform: 'translateY(-1px)' }}>
+          {sidebarCollapsed ? <>
+            <path d="M3 2L7 6L3 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M8 2L12 6L8 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </> : <>
+            <path d="M13 2L9 6L13 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            <path d="M8 2L4 6L8 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+          </>}
+        </svg>
+      </Button>
+      <Divider vertical style={{ height: 20, margin: '0 4px' }} />
       <Typography.Title
         level={3}
         style={{

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,4 +1,5 @@
-import { Button, Collapse, Layout, theme } from 'antd'
+import { Button, Collapse, Drawer, Layout, theme } from 'antd'
+import { COLORS } from '@/theme'
 import LocationFilters from '@/components/filters/LocationFilters'
 import StatsFilters from '@/components/filters/StatsFilters'
 import FeatureFilters from '@/components/filters/FeatureFilters'
@@ -8,7 +9,7 @@ import { useFilters } from '@/hooks/useFilters'
 
 const ALL_KEYS = ['location']
 
-export default function AppSidebar({ meta, allResorts, collapsed, width }) {
+export default function AppSidebar({ meta, allResorts, collapsed, width, isMobile, onClose }) {
   const { resetFilters } = useFilters()
   const { token } = theme.useToken()
 
@@ -40,6 +41,49 @@ export default function AppSidebar({ meta, allResorts, collapsed, width }) {
     },
   ]
 
+  const content = (
+    <>
+      <div style={{ padding: '8px 16px 4px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Button type="link" size="small" danger onClick={resetFilters} style={{ padding: 0 }}>
+          Reset all filters
+        </Button>
+        {isMobile && (
+          <button
+            onClick={onClose}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '4px', display: 'flex', alignItems: 'center', color: COLORS.error }}
+          >
+            <svg width="16" height="12" viewBox="0 0 16 12" fill="none" style={{ display: 'block', transform: 'translateY(-1px)' }}>
+              <path d="M13 2L9 6L13 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+              <path d="M8 2L4 6L8 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+            </svg>
+          </button>
+        )}
+      </div>
+      <Collapse
+        defaultActiveKey={ALL_KEYS}
+        items={items}
+        ghost
+        style={{ padding: '8px 0' }}
+      />
+    </>
+  )
+
+  if (isMobile) {
+    return (
+      <Drawer
+        title={null}
+        closable={false}
+        placement="left"
+        open={!collapsed}
+        onClose={onClose}
+        width={280}
+        styles={{ body: { padding: 0, background: token.colorBgLayout } }}
+      >
+        {content}
+      </Drawer>
+    )
+  }
+
   return (
     <Layout.Sider
       collapsed={collapsed}
@@ -50,17 +94,7 @@ export default function AppSidebar({ meta, allResorts, collapsed, width }) {
         overflow: 'auto',
       }}
     >
-      <div style={{ padding: '12px 16px 4px', display: 'flex', justifyContent: 'flex-end' }}>
-        <Button type="link" size="small" danger onClick={resetFilters} style={{ padding: 0 }}>
-          Reset all filters
-        </Button>
-      </div>
-      <Collapse
-        defaultActiveKey={ALL_KEYS}
-        items={items}
-        ghost
-        style={{ padding: '8px 0' }}
-      />
+      {content}
     </Layout.Sider>
   )
 }

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -8,7 +8,7 @@ import { useFilters } from '@/hooks/useFilters'
 
 const ALL_KEYS = ['location']
 
-export default function AppSidebar({ meta, allResorts }) {
+export default function AppSidebar({ meta, allResorts, collapsed, width }) {
   const { resetFilters } = useFilters()
   const { token } = theme.useToken()
 
@@ -42,12 +42,11 @@ export default function AppSidebar({ meta, allResorts }) {
 
   return (
     <Layout.Sider
-      breakpoint="md"
-      collapsedWidth="0"
-      width={280}
+      collapsed={collapsed}
+      collapsedWidth={0}
+      width={width}
       style={{
         background: token.colorBgLayout,
-        borderRight: `1px solid ${token.colorBorder}`,
         overflow: 'auto',
       }}
     >

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -44,9 +44,6 @@ export default function AppSidebar({ meta, allResorts, collapsed, width, isMobil
   const content = (
     <>
       <div style={{ padding: '8px 16px 4px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Button type="link" size="small" danger onClick={resetFilters} style={{ padding: 0 }}>
-          Reset all filters
-        </Button>
         {isMobile && (
           <button
             onClick={onClose}
@@ -58,6 +55,9 @@ export default function AppSidebar({ meta, allResorts, collapsed, width, isMobil
             </svg>
           </button>
         )}
+        <Button type="link" size="small" danger onClick={resetFilters} style={{ padding: 0, marginLeft: 'auto' }}>
+          Reset all filters
+        </Button>
       </div>
       <Collapse
         defaultActiveKey={ALL_KEYS}


### PR DESCRIPTION
## Summary

- **#103** Collapsible filter sidebar: controlled state (expanded on desktop, collapsed on mobile), double-chevron SVG toggle in the app header separated from the title by a vertical divider, drag-to-resize handle on desktop
- **#104** "Last updated" footer bug: `AppFooter` was rendered without props — wired up `meta.last_pipeline_run` from the already-working `/meta` endpoint
- **#105** Mobile toolbar/footer layout: sidebar now renders as an Ant Design `Drawer` overlay on mobile (< 768px) so content stays full-width; toolbar drag handle and footer use `flexWrap` for narrow viewports; footer attribution shortened to "Google Maps"

Mobile drawer UX details:
- Close chevron is left-aligned (same corner user tapped to open — no button chasing)
- "Reset all filters" is right-aligned
- No antd drawer header chrome — fully custom, matches sidebar background

## Test plan

- [ ] Desktop: sidebar expands/collapses via header chevron, drag handle resizes width
- [ ] Desktop: footer shows "Last updated: [date]" and fits on one line
- [ ] Mobile (< 768px): sidebar starts collapsed, `»` chevron in header opens drawer overlay
- [ ] Mobile: drawer closes via left-aligned `«` chevron inside the drawer
- [ ] Mobile: toolbar buttons wrap rather than clip on narrow screens
- [ ] Mobile: footer wraps cleanly without character-by-character breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)