### PR TITLE
ux(#107, #109): 80s ski-punk theme color pass + Peak Rankings visual encoding

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -122,3 +122,10 @@ Format for new entries:
 **Decision:** Set `min_machines_running = 1` in `backend/fly.toml` (was 0). One machine runs continuously instead of spinning down on idle.
 **Rationale:** With `min_machines_running = 0`, the first request after any idle period incurred a ~2–3s cold start — bad first impression for Facebook link clicks. Cost is ~$3–4/month in prepaid Fly.io credits.
 **Follow-up:** None.
+
+---
+## 2026-05-25 — Theme color pass: 80s ski-punk palette
+**Issue:** #107
+**Decision:** Expanded color palette in `theme.js` with `accentBlue` (#3d52ff), `accentPurple` (#9b00e6), `bgMidtone` (#505050), deepened `primary` to #00c4d4 and `success` to #b4f000 (chartreuse). Map dots: pink=alpine, electric blue=XC, purple=both (pink+blue=purple). Difficulty pie chart: chartreuse=beginner, blue=intermediate, grey=advanced (matches real trail markers). PR bars colored by score value (green/yellow/pink). Dark anchor bands: near-black header, charcoal search band and table drag handle, charcoal table column headers. Features section redesigned as "Label: Yes/No" grid. Neon colors used on dark surfaces; functional colors carry semantic meaning throughout.
+**Rationale:** Original theme used only hot pink and pale cyan; neons were invisible on white. Key insight: neons only work on dark surfaces — structural dark bands provide the canvas. Color choices are functional (map dot mixing, trail marker convention, traffic-light PR scores) not purely decorative.
+**Follow-up:** Dark mode (future) will unlock full neon palette across the whole surface.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -29,15 +29,17 @@ Target: public launch on Indy Pass Facebook groups ahead of ski season.
 | #104 | Bug: "Last updated" not populating | P0 | Done |
 | #105 | Mobile: toolbar and footer layout broken | P0 | Done |
 | #106 | Cold start: keep Fly.io machine warm | P1 | Done |
-| #83 | Data validation on Resort Pydantic model | P1 | Blocks #77 |
-| #77 | GitHub Actions scheduled pipeline | P1 | Depends on #83 |
-| #11 | Bug: alpine+XC metrics parsing | P1 | |
-| #108 | Design: theme color pass | P2 | |
-| #107 | UX: Peak Rankings visual encoding | P2 | |
-| #109 | UX: "How to use" first-load popover | P2 | |
+| #107 | Design: theme color pass | P2 | Done |
+| #109 | UX: Peak Rankings visual encoding | P2 | |
+| #108 | UX: "How to use" first-load popover | P2 | |
 | #110 | UX: "Help improve this app" feedback section | P2 | |
+| #83 | Data validation on Resort Pydantic model | P1 (deferred) | Blocks #77 |
+| #77 | GitHub Actions scheduled pipeline | P1 (deferred) | Depends on #83 |
+| #11 | Bug: alpine+XC metrics parsing | P1 | |
 
-**Next up:** #83 (Pydantic data validation, blocks #77).
+**Next up:** #109 (Peak Rankings visual encoding) or #108 ("How to use" popover).
+
+**#83/#77 deferred:** Cosmetic P2 issues take priority over automated pipeline work — the data being a day or two out-of-date isn't consequential right now.
 
 **#77 revised scope:** Pipeline runs on a schedule and opens a PR against main rather than auto-committing. Human reviews the data diff before merging. Pre-PR sanity check runs `load_resorts()` against the new CSV — any Pydantic validation failures abort the job before a PR is opened. See issue for full acceptance criteria.
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -179,7 +179,7 @@ export default function App() {
           )}
           <Layout>
             <Layout.Content style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-              <div style={{ padding: '12px 24px' }}>
+              <div style={{ padding: '8px 24px', borderBottom: `1px solid ${COLORS.bgHeader}`, background: COLORS.bgMidtone }}>
                 <ResortToolbar count={resorts.length} loading={loading} />
               </div>
               <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
@@ -196,8 +196,8 @@ export default function App() {
                   onMouseDown={tableCollapsed ? undefined : startDrag}
                   style={{
                     minHeight: 28,
-                    background: COLORS.bgLayout,
-                    borderTop: `1px solid ${COLORS.border}`,
+                    background: COLORS.bgHeader,
+                    borderTop: `1px solid ${COLORS.bgHeader}`,
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'space-between',
@@ -209,10 +209,11 @@ export default function App() {
                   }}
                 >
                   <Button
+                    type="primary"
+                    danger
                     size="small"
                     onMouseDown={e => e.stopPropagation()}
                     onClick={() => setTableCollapsed(c => !c)}
-                    style={{ borderColor: COLORS.error, color: COLORS.error }}
                   >
                     {tableCollapsed ? '▲ Expand data table' : '▼ Hide data table'}
                   </Button>
@@ -226,9 +227,9 @@ export default function App() {
                         onOpenChange={setColsOpen}
                         placement="bottomRight"
                       >
-                        <Button size="small">Select Columns</Button>
+                        <Button type="text" size="small" style={{ color: COLORS.success }}>Select Columns</Button>
                       </Popover>
-                      <Button size="small" onClick={onDownloadCsv}>Download CSV</Button>
+                      <Button type="text" size="small" onClick={onDownloadCsv} style={{ color: COLORS.success }}>Download CSV</Button>
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/ResortDetailModal.jsx
+++ b/frontend/src/components/ResortDetailModal.jsx
@@ -4,7 +4,7 @@ import {
   Bar, BarChart, Cell, Pie, PieChart,
   ResponsiveContainer, XAxis,
 } from 'recharts'
-import { Button, Calendar, Divider, Modal, Select, Skeleton, Space, Tag, Typography } from 'antd'
+import { Button, Calendar, Divider, Modal, Select, Skeleton, Space, Typography } from 'antd'
 import { fetchResort } from '@/api/resorts'
 import { classifyBlackoutDates } from '@/utils/blackout'
 import { COLORS } from '@/theme'
@@ -48,9 +48,23 @@ const PR_CATEGORIES = [
 ]
 
 const DIFFICULTY_COLORS = {
-  Beginner:     COLORS.difficultyBeginner,
-  Intermediate: COLORS.primary,
-  Advanced:     COLORS.textMuted,
+  Beginner:     COLORS.success,     // chartreuse — green circle trail marker
+  Intermediate: COLORS.accentBlue,  // electric blue — blue square trail marker
+  Advanced:     COLORS.neutral,     // medium grey — black diamond trail marker
+}
+
+function prBarColor(val) {
+  if (val >= 8) return COLORS.success
+  if (val >= 5) return COLORS.warning
+  return COLORS.error
+}
+
+function SectionHeader({ children, color }) {
+  return (
+    <div style={{ borderLeft: `3px solid ${color}`, paddingLeft: 8, marginBottom: 8 }}>
+      <Text strong>{children}</Text>
+    </div>
+  )
 }
 
 function fmt(value, unit) {
@@ -167,7 +181,7 @@ function PeakRankings({ resort }) {
               <div style={{ fontSize: 16, fontWeight: 600 }}>{val != null ? val : '—'}</div>
               <div style={{ height: 3, borderRadius: 1, background: COLORS.bgLayout, marginTop: 2 }}>
                 {val != null && (
-                  <div style={{ height: '100%', width: `${(val / 10) * 100}%`, background: COLORS.primary, borderRadius: 1 }} />
+                  <div style={{ height: '100%', width: `${(val / 10) * 100}%`, background: prBarColor(val), borderRadius: 1 }} />
                 )}
               </div>
             </div>
@@ -355,29 +369,27 @@ export default function ResortDetailModal({ resortId, onClose }) {
           <Divider />
 
           {/* Features */}
-          <Text strong>Features</Text>
-          <div style={{ marginTop: 8 }}>
-            <Space size={[8, 8]} wrap>
-              {FEATURES.map(({ key, label }) => {
-                const active = resort[key] === true
-                const unknown = resort[key] == null
-                return (
-                  <Tag
-                    key={key}
-                    color={active ? 'success' : undefined}
-                    style={{ opacity: unknown ? 0.4 : 1 }}
-                  >
-                    {label}
-                  </Tag>
-                )
-              })}
-            </Space>
+          <SectionHeader color={COLORS.primary}>Features</SectionHeader>
+          <div style={{ display: 'grid', gridTemplateColumns: 'auto auto 1fr auto auto 1fr auto auto', gap: '4px 4px', alignItems: 'baseline', marginTop: 8 }}>
+            {[FEATURES.slice(0, 3), FEATURES.slice(3)].flatMap((row, rowIdx) =>
+              row.flatMap(({ key, label }, colIdx) => {
+                const val = resort[key]
+                const cells = [
+                  <Text key={`${key}-l`} style={{ fontSize: 12 }}>{label}:</Text>,
+                  <Text key={`${key}-v`} style={{ fontSize: 12, fontWeight: 700, color: val === true ? COLORS.error : COLORS.textMuted, paddingRight: 4 }}>
+                    {val === true ? 'Yes' : val === false ? 'No' : '—'}
+                  </Text>,
+                ]
+                if (colIdx < 2) cells.push(<div key={`sp-${rowIdx}-${colIdx}`} />)
+                return cells
+              })
+            )}
           </div>
 
           <Divider />
 
           {/* Size */}
-          <Text strong>Size</Text>
+          <SectionHeader color={COLORS.accentBlue}>Size</SectionHeader>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', columnGap: 24, marginTop: 8 }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
               {[
@@ -423,7 +435,7 @@ export default function ResortDetailModal({ resortId, onClose }) {
           <Divider />
 
           {/* Blackout Dates */}
-          <Text strong>Blackout Dates</Text>
+          <SectionHeader color={COLORS.error}>Blackout Dates</SectionHeader>
           <div style={{ marginTop: 8 }}>
             <BlackoutCalendar
               standardJson={resort.blackout_all_dates}
@@ -434,7 +446,7 @@ export default function ResortDetailModal({ resortId, onClose }) {
           <Divider />
 
           {/* Peak Rankings */}
-          <Text strong>Peak Rankings</Text>
+          <SectionHeader color={COLORS.success}>Peak Rankings</SectionHeader>
           <div style={{ marginTop: 8 }}>
             <PeakRankings resort={resort} />
           </div>

--- a/frontend/src/components/ResortMap.jsx
+++ b/frontend/src/components/ResortMap.jsx
@@ -175,7 +175,8 @@ function MapLegend() {
         position: 'absolute',
         bottom: 32,
         left: 16,
-        background: COLORS.bgOverlay,
+        background: COLORS.bgBase,
+        border: `2px solid ${COLORS.bgHeader}`,
         borderRadius: 4,
         padding: '8px 12px',
         display: 'flex',
@@ -195,7 +196,7 @@ function MapLegend() {
               flexShrink: 0,
             }}
           />
-          <span style={{ color: COLORS.bgBase, fontSize: 11, fontFamily: FONTS.mono }}>
+          <span style={{ color: COLORS.text, fontSize: 11, fontFamily: FONTS.mono }}>
             {label}
           </span>
         </div>

--- a/frontend/src/components/ResortTable.jsx
+++ b/frontend/src/components/ResortTable.jsx
@@ -25,7 +25,7 @@ function LinkCell({ value }) {
       target="_blank"
       rel="noreferrer"
       onClick={e => e.stopPropagation()}
-      style={{ color: COLORS.success }}
+      style={{ color: COLORS.accentBlue }}
     >
       {value}
     </a>
@@ -143,7 +143,7 @@ const GRID_THEME_VARS = {
   '--ag-border-color':                  COLORS.border,
   '--ag-header-column-separator-color': COLORS.border,
   '--ag-cell-horizontal-padding':       '8px',
-  '--indy-header-bg':                   COLORS.bgHeader,
+  '--indy-header-bg':                   COLORS.bgMidtone,
   '--indy-header-hover':                COLORS.neutral,
   '--indy-header-text':                 COLORS.bgBase,
 }

--- a/frontend/src/components/ResortToolbar.jsx
+++ b/frontend/src/components/ResortToolbar.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Input, Typography } from 'antd'
 import { useFilters } from '@/hooks/useFilters'
+import { COLORS } from '@/theme'
 
 export default function ResortToolbar({ count, loading }) {
   const { filters, setFilter } = useFilters()
@@ -18,7 +19,7 @@ export default function ResortToolbar({ count, loading }) {
   }, [localSearch])
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 16 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
       <Input.Search
         placeholder="Search resorts..."
         value={localSearch}
@@ -27,7 +28,7 @@ export default function ResortToolbar({ count, loading }) {
         allowClear
         style={{ maxWidth: 360 }}
       />
-      <Typography.Text type="secondary" style={{ fontSize: 12, whiteSpace: 'nowrap' }}>
+      <Typography.Text style={{ fontSize: 12, whiteSpace: 'nowrap', color: COLORS.success }}>
         {count} resort{count !== 1 ? 's' : ''} found
       </Typography.Text>
     </div>

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -19,9 +19,9 @@ export default function AppFooter({ lastUpdated }) {
         Data sourced from{' '}
         <Typography.Link style={{ color: token.colorError }} href="https://www.indyskipass.com" target="_blank">Indy Pass</Typography.Link>
         {', '}
-        <Typography.Link style={{ color: token.colorError }} href="https://peakrankings.com" target="_blank">Peak Rankings</Typography.Link>
+        <Typography.Link style={{ color: token.colorSuccess }} href="https://peakrankings.com" target="_blank">Peak Rankings</Typography.Link>
         {', and '}
-        <Typography.Link style={{ color: token.colorError }} href="https://developers.google.com/maps/documentation/geocoding" target="_blank">Google Maps</Typography.Link>
+        <Typography.Link style={{ color: token.colorPrimary }} href="https://developers.google.com/maps/documentation/geocoding" target="_blank">Google Maps</Typography.Link>
       </Typography.Text>
       <Typography.Text type="secondary" style={{ fontSize: 12 }}>
         Last updated: {lastUpdated ?? '—'}

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -9,8 +9,7 @@ export default function AppHeader({ sidebarCollapsed, onToggleSidebar }) {
         display: 'flex',
         alignItems: 'center',
         gap: 12,
-        background: token.colorBgContainer,
-        borderBottom: `1px solid ${token.colorBorder}`,
+        background: COLORS.bgHeader,
         padding: '0 24px',
         height: 56,
         lineHeight: '56px',
@@ -38,8 +37,12 @@ export default function AppHeader({ sidebarCollapsed, onToggleSidebar }) {
         style={{
           margin: 0,
           fontFamily: FONTS.display,
-          letterSpacing: '0.05em',
-          color: token.colorTextBase,
+          letterSpacing: '0.08em',
+          color: COLORS.error,
+          fontWeight: 400,
+          fontSize: 28,
+          WebkitFontSmoothing: 'antialiased',
+          WebkitTextStroke: `0.5px ${COLORS.error}`,
         }}
       >
         Indy Explorer

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -13,15 +13,24 @@ export default function AppSidebar({ meta, allResorts, collapsed, width, isMobil
   const { resetFilters } = useFilters()
   const { token } = theme.useToken()
 
+  function sectionLabel(text, color) {
+    return (
+      <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ display: 'inline-block', width: 8, height: 8, borderRadius: '50%', background: color, flexShrink: 0 }} />
+        {text}
+      </span>
+    )
+  }
+
   const items = [
     {
       key: 'location',
-      label: 'Location',
+      label: sectionLabel('Location', COLORS.primary),
       children: <LocationFilters meta={meta} allResorts={allResorts ?? []} />,
     },
     {
       key: 'resort-filters',
-      label: 'Stats and Features',
+      label: sectionLabel('Stats and Features', COLORS.accentBlue),
       children: (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
           <StatsFilters meta={meta} />
@@ -31,12 +40,12 @@ export default function AppSidebar({ meta, allResorts, collapsed, width, isMobil
     },
     {
       key: 'blackout',
-      label: 'Blackout Dates',
+      label: sectionLabel('Blackout Dates', COLORS.error),
       children: <BlackoutDateFilters />,
     },
     {
       key: 'peak-rankings',
-      label: 'Peak Rankings',
+      label: sectionLabel('Peak Rankings', COLORS.success),
       children: <PeakRankingsFilters meta={meta} />,
     },
   ]

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,24 +1,27 @@
 import { theme as antdTheme } from 'antd'
 
 export const COLORS = {
-  primary:             '#00f5ff',
-  success:             '#39ff14',
-  warning:             '#ffdd00',
-  error:               '#ff006e',
-  neutral:             '#808080',
-  primaryBorder:       '#00b8c8',
-  primaryHover:        '#00d9e8',
-  primaryActive:       '#0099a8',
-  text:                '#0d0d0d',
-  textMuted:           '#666666',
-  border:              '#e0e0e0',
-  bgBase:              '#ffffff',
-  bgLayout:            '#f5f5f5',
-  bgSidebar:           '#fafafa',
-  bgHeader:            '#505050',
-  bgOverlay:           'rgba(0,0,0,0.75)',
-  shadow:              'rgba(0,0,0,0.15)',
-  difficultyBeginner:  '#00C44F',
+  primary:       '#00c4d4',   // electric teal — UI accents, links, fills on dark
+  success:       '#b4f000',   // chartreuse — high scores, active features, beginner trails
+  warning:       '#ffc400',   // amber — mid scores, caution
+  error:         '#ff006e',   // hot pink — low scores, alpine dots, standard blackouts
+  neutral:       '#808080',
+  accentBlue:    '#3d52ff',
+  bgMidtone:        '#505050',   // charcoal — search band, table column headers, input borders
+  inputPlaceholder: '#888888',   // electric blue — XC dots, intermediate trails
+  accentPurple:  '#9b00e6',   // neon purple — Alpine+XC dots (pink + blue)
+  primaryBorder: '#00b8c8',
+  primaryHover:  '#00d9e8',
+  primaryActive: '#0099a8',
+  text:          '#0d0d0d',
+  textMuted:     '#666666',
+  border:        '#e0e0e0',
+  bgBase:        '#ffffff',
+  bgLayout:      '#f5f5f5',
+  bgSidebar:     '#fafafa',
+  bgHeader:      '#111111',   // near-black anchor — app header, table header, drag handle
+  bgOverlay:     'rgba(0,0,0,0.75)',
+  shadow:        'rgba(0,0,0,0.15)',
 }
 
 export function withAlpha(hex, alpha) {
@@ -42,10 +45,15 @@ export const FONTS = {
 
 // Deck.gl requires colors as [R, G, B, A] arrays (A: 0–255).
 export const MAP_DOT_COLORS = {
-  alpine: hexToRgba(COLORS.error,   200),
-  xc:     hexToRgba(COLORS.primary, 200),
-  both:   hexToRgba(COLORS.success, 200),
-  allied: hexToRgba(COLORS.neutral, 180),
+  alpine: hexToRgba(COLORS.error,        200),  // hot pink
+  xc:     hexToRgba(COLORS.accentBlue,   200),  // electric blue
+  both:   hexToRgba(COLORS.accentPurple, 200),  // purple = pink + blue
+  allied: hexToRgba(COLORS.neutral,      180),
+}
+
+const INPUT_TOKENS = {
+  colorBorder:          COLORS.bgMidtone,
+  colorTextPlaceholder: COLORS.inputPlaceholder,
 }
 
 export const themeConfig = {
@@ -66,5 +74,10 @@ export const themeConfig = {
     colorBorder:        COLORS.border,
     borderRadius:       2,
     fontFamily:         FONTS.mono,
+  },
+  components: {
+    Input:  INPUT_TOKENS,
+    Select: INPUT_TOKENS,
+    Button: { colorBorder: COLORS.bgMidtone },
   },
 }


### PR DESCRIPTION
## Summary
- Expanded color palette in `theme.js`: `accentBlue`, `accentPurple`, `bgMidtone`, deeper `primary` (teal) and `success` (chartreuse)
- Map dots redesigned with intuitive mixing: pink=alpine, electric blue=XC, purple=both (pink+blue=purple)
- Difficulty pie chart colors match real ski trail markers: chartreuse=beginner, blue=intermediate, grey=advanced
- Peak Rankings bars colored by score value (#109): green (8–10), yellow (5–7), pink (1–4)
- Dark anchor bands throughout: near-black app header, charcoal search band, charcoal drag handle, charcoal table column headers
- Features section in resort modal redesigned as scannable "Label: Yes/No" grid
- Neon colors reserved for dark surfaces; all color choices carry functional meaning

## Test plan
- [ ] Map dot colors render correctly (pink/blue/purple/grey) and legend matches
- [ ] Difficulty pie chart shows chartreuse/blue/grey slices
- [ ] Peak Rankings score bars show green/yellow/pink by value
- [ ] Features grid shows "Label: Yes/No" with pink Yes, grey No
- [ ] Dark header, charcoal search band, charcoal drag handle all render correctly
- [ ] All colors in `.jsx` files reference `COLORS` tokens — no hardcoded hex

Closes #107
Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)