### PR TITLE
ux(#113): mobile UI polish — tab layout, attribution, modal, legend

### DIFF
--- a/docs/planning.md
+++ b/docs/planning.md
@@ -6,7 +6,7 @@ Current work-in-progress. Update this file at the start and end of every session
 
 ## Current Branch
 
-`feature/polish-ui-for-mobile`
+`main` (no active feature branch)
 
 ## Status (as of 2026-05-30)
 
@@ -37,13 +37,13 @@ Target: public launch on Indy Pass Facebook groups ahead of ski season.
 | #77 | GitHub Actions scheduled pipeline | P1 (deferred) | Depends on #83 |
 | #11 | Bug: alpine+XC metrics parsing | P1 | |
 
-**PR open (#113):** feature/polish-ui-for-mobile — awaiting review + merge
+**#113 merged and deployed (2026-05-30):**
 - Map/Table tab switcher, footer hidden, unified attribution ⓘ in tab bar
 - Collapsible map legend (top-left, outside DeckGL, format_list_bulleted icon)
 - Modal: responsive features/PR grids, pie chart hidden on mobile
 - PR score bars: 5-color scale (prMid #8b6ab5, prTop #40b050)
 
-**Next up:** merge + deploy #113, then #108 or #110.
+**Next up:** #108 ("How to use" first-load popover) or #110 ("Help improve this app" feedback section).
 
 **#83/#77 deferred:** Cosmetic P2 issues take priority over automated pipeline work — the data being a day or two out-of-date isn't consequential right now.
 

--- a/frontend/src/components/ResortDetailModal.jsx
+++ b/frontend/src/components/ResortDetailModal.jsx
@@ -75,7 +75,6 @@ function fmt(value, unit) {
 }
 
 function DifficultyChart({ beginner, intermediate, advanced, isMobile }) {
-  if (isMobile) return null
   if (beginner == null && intermediate == null && advanced == null) return null
   const data = [
     { name: 'Beginner',     value: Number(beginner     || 0) },
@@ -96,13 +95,15 @@ function DifficultyChart({ beginner, intermediate, advanced, isMobile }) {
             <Text key={`${d.name}-v`} strong style={{ fontSize: 12 }}>{d.value}%</Text>,
           ])}
         </div>
-        <ResponsiveContainer width="100%" height={70}>
-          <PieChart>
-            <Pie data={data} dataKey="value" cx="50%" cy="50%" outerRadius={30} isAnimationActive={false}>
-              {data.map(entry => <Cell key={entry.name} fill={DIFFICULTY_COLORS[entry.name]} />)}
-            </Pie>
-          </PieChart>
-        </ResponsiveContainer>
+        {!isMobile && (
+          <ResponsiveContainer width="100%" height={70}>
+            <PieChart>
+              <Pie data={data} dataKey="value" cx="50%" cy="50%" outerRadius={30} isAnimationActive={false}>
+                {data.map(entry => <Cell key={entry.name} fill={DIFFICULTY_COLORS[entry.name]} />)}
+              </Pie>
+            </PieChart>
+          </ResponsiveContainer>
+        )}
       </div>
     </div>
   )
@@ -440,7 +441,7 @@ export default function ResortDetailModal({ resortId, onClose, isMobile = false 
           {hasCharts && (
             <>
               <Divider />
-              <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr', gap: '0 32px', alignItems: 'start' }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0 32px', alignItems: 'start' }}>
                 <DifficultyChart
                   beginner={resort.difficulty_beginner}
                   intermediate={resort.difficulty_intermediate}


### PR DESCRIPTION
## Summary

- **Mobile tab layout**: replaced broken footer with a fixed tab bar (Map | Table | ⓘ); footer hidden on mobile
- **Attribution**: unified Mapbox + data source attribution into a ⓘ popup in the tab bar; custom div (not Ant Design Popover) to avoid z-index and styling issues with DeckGL canvas
- **Map legend**: collapsible with × to close, pill button with `format_list_bulleted` SVG icon to reopen; positioned top-left outside DeckGL
- **Resort detail modal**: responsive Features grid (2-col on mobile), Trail Difficulty legend always visible with pie chart hidden on mobile, charts section always side-by-side, Peak Rankings grid responsive (4-col on mobile)
- **PR score bars**: 5-color scale — error < 3, warning 3–4, prMid (muted purple) 5–6, primary (teal) 7–8, prTop (rich green) > 8
- **New theme tokens**: `prMid: '#8b6ab5'`, `prTop: '#40b050'`

## Test plan

- [ ] Mobile: tab bar switches between Map and Table views
- [ ] Mobile: ⓘ button shows attribution popup anchored above tab bar, padded from edges
- [ ] Mobile: map legend opens/closes correctly; legend button renders outside DeckGL (not blocked by canvas)
- [ ] Mobile: resort detail modal — Features grid, Trail Difficulty legend + Snowfall side-by-side, Peak Rankings 4-col grid
- [ ] Desktop: no regressions — footer visible, map legend, table panel, modal layout all unchanged
- [ ] PR score bars show 5 distinct colors across the 0–10 range

🤖 Generated with [Claude Code](https://claude.com/claude-code)