### PR TITLE
feat: continuous HSL color scale for Peak Rankings bars

### DIFF
--- a/frontend/src/components/ResortDetailModal.jsx
+++ b/frontend/src/components/ResortDetailModal.jsx
@@ -7,7 +7,7 @@ import {
 import { Button, Calendar, Divider, Modal, Select, Skeleton, Space, Typography } from 'antd'
 import { fetchResort } from '@/api/resorts'
 import { classifyBlackoutDates } from '@/utils/blackout'
-import { COLORS } from '@/theme'
+import { COLORS, hexToHsl } from '@/theme'
 
 // Persists the user's last-viewed month across modal opens
 let sharedCalendarMonth = dayjs()
@@ -53,12 +53,33 @@ const DIFFICULTY_COLORS = {
   Advanced:     COLORS.neutral,     // medium grey — black diamond trail marker
 }
 
-function prBarColor(val) {
-  if (val > 8)  return COLORS.prTop
-  if (val >= 7) return COLORS.primary
-  if (val >= 5) return COLORS.prMid
-  if (val >= 3) return COLORS.warning
-  return COLORS.error
+const SCORE_COLOR_ANCHORS = [
+  [1, COLORS.prScore1],  // deep crimson
+  [4, COLORS.warning],   // amber
+  [7, COLORS.success],   // chartreuse
+  [9, COLORS.prScore10], // deep green
+]
+
+function scoreToColor(score) {
+  if (score > 10) return COLORS.primary
+  const s = Math.max(1, score)
+  const anchors = SCORE_COLOR_ANCHORS
+  let lo = anchors[0], hi = anchors[anchors.length - 1]
+  for (let i = 0; i < anchors.length - 1; i++) {
+    if (s >= anchors[i][0] && s <= anchors[i + 1][0]) {
+      lo = anchors[i]; hi = anchors[i + 1]; break
+    }
+  }
+  const t = (s - lo[0]) / (hi[0] - lo[0])
+  const [lh, ls, ll] = hexToHsl(lo[1])
+  const [hh, hs, hl] = hexToHsl(hi[1])
+  let dh = hh - lh
+  if (dh > 180) dh -= 360
+  if (dh < -180) dh += 360
+  const h = ((lh + t * dh) + 360) % 360
+  const sat = ls + t * (hs - ls)
+  const lit = ll + t * (hl - ll)
+  return `hsl(${h.toFixed(1)},${sat.toFixed(1)}%,${lit.toFixed(1)}%)`
 }
 
 function SectionHeader({ children, color }) {
@@ -185,7 +206,7 @@ function PeakRankings({ resort, isMobile }) {
               <div style={{ fontSize: 16, fontWeight: 600 }}>{val != null ? val : '—'}</div>
               <div style={{ height: 3, borderRadius: 1, background: COLORS.bgLayout, marginTop: 2 }}>
                 {val != null && (
-                  <div style={{ height: '100%', width: `${(val / 10) * 100}%`, background: prBarColor(val), borderRadius: 1 }} />
+                  <div style={{ height: '100%', width: `${(val / 10) * 100}%`, background: scoreToColor(val), borderRadius: 1 }} />
                 )}
               </div>
             </div>

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -22,8 +22,26 @@ export const COLORS = {
   bgHeader:      '#111111',   // near-black anchor — app header, table header, drag handle
   prMid:         '#8b6ab5',   // muted purple — middle tier (5–6) on PR score bars
   prTop:         '#40b050',   // rich green — top tier (9–10) on PR score bars
+  prScore1:      '#c0001a',   // deep crimson — PR continuous scale bottom anchor (score 1)
+  prScore10:     '#78bc00',   // deep green   — PR continuous scale top anchor (score 10)
   bgOverlay:     'rgba(0,0,0,0.75)',
   shadow:        'rgba(0,0,0,0.15)',
+}
+
+export function hexToHsl(hex) {
+  let r = parseInt(hex.slice(1, 3), 16) / 255
+  let g = parseInt(hex.slice(3, 5), 16) / 255
+  let b = parseInt(hex.slice(5, 7), 16) / 255
+  const max = Math.max(r, g, b), min = Math.min(r, g, b)
+  const l = (max + min) / 2
+  if (max === min) return [0, 0, l * 100]
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  let h
+  if (max === r)      h = ((g - b) / d + (g < b ? 6 : 0)) / 6
+  else if (max === g) h = ((b - r) / d + 2) / 6
+  else                h = ((r - g) / d + 4) / 6
+  return [h * 360, s * 100, l * 100]
 }
 
 export function withAlpha(hex, alpha) {


### PR DESCRIPTION
## Summary

- Replaces the 5-step discrete `prBarColor` palette with a smooth HSL-interpolated continuous scale via `scoreToColor`
- Anchor stops at scores 1/4/7/9 — calibrated to the actual score distribution (bell curve centered ~5–6) so color transitions span where data actually lives, not a uniform 1–10 spread
- Adds `hexToHsl` utility to `theme.js` alongside the existing `withAlpha`/`hexToRgba` helpers
- Adds `prScore1` (#c0001a deep crimson) and `prScore10` (#78bc00 deep green) to `COLORS` as anchor endpoints; mid-scale anchors reuse existing `warning` (amber) and `success` (chartreuse) tokens

## Test plan

- [ ] Open resort modals across a range of scores (low, mid, high) and confirm bars show the full crimson → amber → chartreuse → green gradient
- [ ] Confirm scores 1–2 show crimson/red tones, 4–5 amber, 6–7 yellow-green, 8–9 bright green
- [ ] Confirm no regressions in other modal sections (blackout calendar, difficulty chart, snowfall chart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)