### PR TITLE
UI polish queue #116 — tooltips, sidebar filters, mobile chrome

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -148,6 +148,7 @@ def get_resorts(
     pr_ability_low: list[str] = Query(default=[]),
     pr_ability_high: list[str] = Query(default=[]),
     # Blackout date range filters (YYYY-MM-DD; show resorts with no blackouts in the range)
+    has_blackouts: Optional[bool] = Query(default=None),
     blackout_date_from: Optional[str] = Query(default=None),
     blackout_date_to: Optional[str] = Query(default=None),
     ltt_date_from: Optional[str] = Query(default=None),
@@ -245,6 +246,12 @@ def get_resorts(
         if values:
             value_set = {v.lower() for v in values}
             results = [r for r in results if (getattr(r, field) or '').lower() in value_set]
+
+    if has_blackouts is not None:
+        if has_blackouts:
+            results = [r for r in results if (r.blackout_count or 0) > 0]
+        else:
+            results = [r for r in results if (r.blackout_count or 0) == 0]
 
     # Blackout date range filters — exclude resorts with any blackout within [from, to]
     if blackout_date_from or blackout_date_to:

--- a/backend/tests/test_resorts_blackout_filters.py
+++ b/backend/tests/test_resorts_blackout_filters.py
@@ -14,6 +14,7 @@ from models import Resort
 
 # Helper to build a minimal Resort with the fields we care about
 def make_resort(resort_id, name, blackout_dates=None, ltt_blackout_dates=None, ltt_available=False):
+    dates = blackout_dates or []
     return Resort(
         resort_id=resort_id,
         name=name,
@@ -21,7 +22,8 @@ def make_resort(resort_id, name, blackout_dates=None, ltt_blackout_dates=None, l
         reservation_status='Not Required',
         indy_page=f'https://example.com/{resort_id}',
         ltt_available=ltt_available,
-        blackout_all_dates=json.dumps(blackout_dates or []),
+        blackout_all_dates=json.dumps(dates),
+        blackout_count=len(dates),
         ltt_blackout_all_dates=json.dumps(ltt_blackout_dates or []),
     )
 
@@ -186,3 +188,26 @@ def test_all_filter_types_combined(client):
     # Nordic Valley: LTT ✓, not blacked out Dec 25 ✓, Feb 14 not in ltt_blackout ✓
     names = {r['name'] for r in response.json()}
     assert names == {'Nordic Valley'}
+
+
+# --- has_blackouts ---
+
+
+def test_has_blackouts_true(client):
+    response = client.get('/resorts?has_blackouts=true')
+    assert response.status_code == 200
+    names = {r['name'] for r in response.json()}
+    assert names == {'Alpine Peak', 'Nordic Valley'}
+
+
+def test_has_blackouts_false(client):
+    response = client.get('/resorts?has_blackouts=false')
+    assert response.status_code == 200
+    names = {r['name'] for r in response.json()}
+    assert names == {'Powder Ridge'}
+
+
+def test_has_blackouts_combined_with_ltt_available(client):
+    response = client.get('/resorts?has_blackouts=false&ltt_available=false')
+    names = {r['name'] for r in response.json()}
+    assert names == {'Powder Ridge'}

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -57,7 +57,9 @@ Target: public launch on Indy Pass Facebook groups ahead of ski season.
 Small tasks interspersed with larger feature work. Check off here and in the GitHub issue as completed.
 
 - [x] Simplify resort tooltips
-- [ ] Pinned filter section headers in sidebar
+- [x] Pinned filter section headers in sidebar
+- [x] Expand LTT → "Learn to Turn" throughout
+- [x] Sidebar: Planning section (blackout dates + reservation), has-blackouts toggle, Has Peak Rankings toggle
 - [ ] Align data table buttons
 - [ ] Reduce height of bar elements on mobile
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -47,6 +47,20 @@ Target: public launch on Indy Pass Facebook groups ahead of ski season.
 - Trail Difficulty legend always visible on mobile (pie chart hidden, legend shown)
 - Trail Difficulty + Snowfall always side-by-side (removed mobile single-column override)
 
+**#115 merged (2026-05-31):**
+- Peak Rankings bars: continuous HSL color scale replacing 5-step discrete palette
+- Anchor stops at 1/4/7/9 (calibrated to actual score distribution, bell curve ~5–6)
+- Added `hexToHsl` helper and `prScore1`/`prScore10` tokens to theme.js
+
+### UI polish queue (#116)
+
+Small tasks interspersed with larger feature work. Check off here and in the GitHub issue as completed.
+
+- [x] Simplify resort tooltips
+- [ ] Pinned filter section headers in sidebar
+- [ ] Align data table buttons
+- [ ] Reduce height of bar elements on mobile
+
 **Next up:** #108 ("How to use" first-load popover) or #110 ("Help improve this app" feedback section).
 
 **#83/#77 deferred:** Cosmetic P2 issues take priority over automated pipeline work — the data being a day or two out-of-date isn't consequential right now.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -60,8 +60,8 @@ Small tasks interspersed with larger feature work. Check off here and in the Git
 - [x] Pinned filter section headers in sidebar
 - [x] Expand LTT → "Learn to Turn" throughout
 - [x] Sidebar: Planning section (blackout dates + reservation), has-blackouts toggle, Has Peak Rankings toggle
-- [ ] Align data table buttons
-- [ ] Reduce height of bar elements on mobile
+- [x] Align data table buttons
+- [x] Reduce height of bar elements on mobile
 
 **Next up:** #108 ("How to use" first-load popover) or #110 ("Help improve this app" feedback section).
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "playwright": "^1.60.0",
         "tailwindcss": "^4.2.1",
         "vite": "^8.0.0",
         "vitest": "^4.1.7"
@@ -5164,6 +5165,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4.2.1",
     "vite": "^8.0.0",
     "vitest": "^4.1.7"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -181,7 +181,7 @@ export default function App() {
     return (
       <ConfigProvider theme={themeConfig}>
         <Layout style={{ height: '100%' }}>
-          <AppHeader sidebarCollapsed={sidebarCollapsed} onToggleSidebar={() => setSidebarCollapsed(c => !c)} />
+          <AppHeader sidebarCollapsed={sidebarCollapsed} onToggleSidebar={() => setSidebarCollapsed(c => !c)} isMobile />
           <Layout>
             <AppSidebar
               meta={meta}
@@ -193,7 +193,7 @@ export default function App() {
             />
             <Layout>
               <Layout.Content style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-                <div style={{ padding: '8px 12px', borderBottom: `1px solid ${COLORS.bgHeader}`, background: COLORS.bgMidtone, flexShrink: 0 }}>
+                <div style={{ padding: '4px 12px', borderBottom: `1px solid ${COLORS.bgHeader}`, background: COLORS.bgMidtone, flexShrink: 0 }}>
                   <ResortToolbar count={resorts.length} loading={loading} />
                 </div>
 
@@ -206,7 +206,7 @@ export default function App() {
                   )}
                   {mobileTab === 'table' && (
                     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-                      <div style={{ display: 'flex', gap: 8, padding: '4px 12px', background: COLORS.bgHeader, borderBottom: `1px solid ${COLORS.border}`, flexShrink: 0, justifyContent: 'flex-end' }}>
+                      <div style={{ display: 'flex', gap: 8, padding: '2px 12px', background: COLORS.bgHeader, borderBottom: `1px solid ${COLORS.border}`, flexShrink: 0, justifyContent: 'flex-end' }}>
                         <Popover
                           content={colsContent}
                           title="Show / hide columns"
@@ -253,7 +253,7 @@ export default function App() {
                         onClick={() => setMobileTab(tab)}
                         style={{
                           flex: 1,
-                          height: 48,
+                          height: 36,
                           background: 'transparent',
                           border: 'none',
                           borderTop: `2px solid ${mobileTab === tab ? COLORS.error : 'transparent'}`,
@@ -273,7 +273,7 @@ export default function App() {
                       onClick={() => setInfoOpen(o => !o)}
                       style={{
                         width: 44,
-                        height: 48,
+                        height: 36,
                         flexShrink: 0,
                         background: 'transparent',
                         border: 'none',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -206,7 +206,7 @@ export default function App() {
                   )}
                   {mobileTab === 'table' && (
                     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-                      <div style={{ display: 'flex', gap: 8, padding: '4px 12px', background: COLORS.bgHeader, borderBottom: `1px solid ${COLORS.border}`, flexShrink: 0 }}>
+                      <div style={{ display: 'flex', gap: 8, padding: '4px 12px', background: COLORS.bgHeader, borderBottom: `1px solid ${COLORS.border}`, flexShrink: 0, justifyContent: 'flex-end' }}>
                         <Popover
                           content={colsContent}
                           title="Show / hide columns"
@@ -369,7 +369,7 @@ export default function App() {
                     {tableCollapsed ? '▲ Expand data table' : '▼ Hide data table'}
                   </Button>
                   {!tableCollapsed && (
-                    <div style={{ display: 'flex', gap: 8 }} onMouseDown={e => e.stopPropagation()}>
+                    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }} onMouseDown={e => e.stopPropagation()}>
                       <Popover
                         content={colsContent}
                         title="Show / hide columns"

--- a/frontend/src/components/ResortDetailModal.jsx
+++ b/frontend/src/components/ResortDetailModal.jsx
@@ -331,7 +331,7 @@ function BlackoutCalendar({ standardJson, lttJson }) {
           <>
             <Space size={6}>
               <span style={{ display: 'inline-block', width: 12, height: 12, borderRadius: '50%', background: COLORS.primary }} />
-              <Text style={{ fontSize: 11 }}>LTT</Text>
+              <Text style={{ fontSize: 11 }}>Learn to Turn</Text>
             </Space>
             <Space size={6}>
               <span style={{ display: 'inline-block', width: 12, height: 12, borderRadius: '50%', background: `linear-gradient(135deg, ${COLORS.error} 50%, ${COLORS.primary} 50%)` }} />

--- a/frontend/src/components/ResortMap.jsx
+++ b/frontend/src/components/ResortMap.jsx
@@ -120,22 +120,17 @@ function fitViewToResorts(resorts, width, height, filters) {
 
 function MapTooltip({ info }) {
   const { resort: r, x, y, flipX, flipY } = info
-  const location = [r.city, r.state, r.country].filter(Boolean).join(', ')
+  const locationParts = r.country === 'United States'
+    ? [r.city, r.state]
+    : [r.city, r.state, r.country]
+  const location = locationParts.filter(Boolean).join(', ')
   const rows = [
-    ['Resort',         r.name],
-    ['Location',       location || '—'],
-    ['Acres',          r.acres != null ? r.acres.toLocaleString() : '—'],
-    ['Vertical',       r.vertical != null ? `${r.vertical.toLocaleString()} ft` : '—'],
-    ['Trails',         r.num_trails != null ? r.num_trails : '—'],
-    ['Lifts',          r.num_lifts != null ? r.num_lifts : '—'],
-    ['Alpine',         yesNo(r.has_alpine)],
-    ['Cross-country',  yesNo(r.has_cross_country)],
-    ['Night skiing',   yesNo(r.has_night_skiing)],
-    ['Terrain parks',  yesNo(r.has_terrain_parks)],
-    ['Dog friendly',   yesNo(r.is_dog_friendly)],
-    ['Reservations',   r.reservation_status ?? '—'],
-    ['Blackout dates', r.blackout_count > 0 ? 'Yes' : 'No'],
-    ['Peak score',     r.pr_total != null ? r.pr_total : '—'],
+    ['Resort',   r.name],
+    ['Location', location || '—'],
+    ['Acres',    r.acres != null ? r.acres.toLocaleString() : '—'],
+    ['Vertical', r.vertical != null ? `${r.vertical.toLocaleString()} ft` : '—'],
+    ['Trails',   r.num_trails != null ? r.num_trails : '—'],
+    ['Lifts',    r.num_lifts != null ? r.num_lifts : '—'],
   ]
   return (
     <div style={{
@@ -252,11 +247,6 @@ function MapLegend() {
   )
 }
 
-function yesNo(val) {
-  if (val === true) return 'Yes'
-  if (val === false) return 'No'
-  return '—'
-}
 
 
 export default function ResortMap({ resorts = [], onResortClick }) {

--- a/frontend/src/components/ResortTable.jsx
+++ b/frontend/src/components/ResortTable.jsx
@@ -79,12 +79,12 @@ export const COLUMN_DEFS = [
   { field: 'has_terrain_parks', headerName: 'Terrain Parks', width: 116, cellRenderer: BoolCell },
   { field: 'is_dog_friendly',   headerName: 'Dog Friendly',  width: 110, cellRenderer: BoolCell },
   { field: 'has_snowshoeing',   headerName: 'Snowshoeing',   width: 120, cellRenderer: BoolCell },
-  { field: 'ltt_available',     headerName: 'LTT',           width: 54,  cellRenderer: BoolCell },
+  { field: 'ltt_available',     headerName: 'Learn to Turn', width: 122, cellRenderer: BoolCell },
   { field: 'is_allied',         headerName: 'Allied',        width: 74,  cellRenderer: BoolCell },
 
   // Blackout
   { field: 'blackout_count',     headerName: 'Blackout Dates', width: 122, valueFormatter: numFmt },
-  { field: 'ltt_blackout_count', headerName: 'LTT Blackouts',  width: 120, valueFormatter: numFmt },
+  { field: 'ltt_blackout_count', headerName: 'Learn to Turn Blackouts', width: 180, valueFormatter: numFmt },
 
   // Reservations
   { field: 'reservation_status', headerName: 'Reservations',    width: 120 },

--- a/frontend/src/components/filters/BlackoutDateFilters.jsx
+++ b/frontend/src/components/filters/BlackoutDateFilters.jsx
@@ -1,8 +1,17 @@
-import { Button, DatePicker, Typography } from 'antd'
+import { DatePicker, Divider, Typography } from 'antd'
 import dayjs from 'dayjs'
 import { useFilters } from '@/hooks/useFilters'
+import { FeatureToggle } from '@/components/filters/FeatureFilters'
 
 const { Text } = Typography
+
+function SectionHeading({ children }) {
+  return (
+    <Divider orientation="left" orientationMargin={0} plain style={{ margin: '4px 0' }}>
+      <Text type="secondary" style={{ fontSize: 11 }}>{children}</Text>
+    </Divider>
+  )
+}
 
 function BlackoutRangePicker({ label, fromKey, toKey }) {
   const { filters, setFilters } = useFilters()
@@ -30,44 +39,21 @@ function BlackoutRangePicker({ label, fromKey, toKey }) {
   )
 }
 
-function LttAvailableToggle() {
-  const { filters, setFilter } = useFilters()
-  const current = filters.ltt_available
-  const yesActive = current === undefined || current === true
-  const noActive  = current === undefined || current === false
-
-  function toggleYes() {
-    if (current === true) setFilter('ltt_available', null)
-    else                  setFilter('ltt_available', true)
-  }
-
-  function toggleNo() {
-    if (current === false) setFilter('ltt_available', null)
-    else                   setFilter('ltt_available', false)
-  }
-
-  return (
-    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
-      <Text style={{ fontSize: 12, flex: 1 }}>LTT available</Text>
-      <Button.Group size="small">
-        <Button type={yesActive ? 'primary' : 'default'} onClick={toggleYes}>Yes</Button>
-        <Button type={noActive  ? 'primary' : 'default'} onClick={toggleNo}>No</Button>
-      </Button.Group>
-    </div>
-  )
-}
-
 export default function BlackoutDateFilters() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <FeatureToggle label="Reservation required" filterKey="reservation_required" />
+      <SectionHeading>Lift Ticket</SectionHeading>
+      <FeatureToggle label="Blackout dates" filterKey="has_blackouts" />
       <BlackoutRangePicker
-        label="Lift ticket available on"
+        label="Available on"
         fromKey="blackout_date_from"
         toKey="blackout_date_to"
       />
-      <LttAvailableToggle />
+      <SectionHeading>Learn to Turn</SectionHeading>
+      <FeatureToggle label="Offered" filterKey="ltt_available" />
       <BlackoutRangePicker
-        label="LTT available on"
+        label="Available on"
         fromKey="ltt_date_from"
         toKey="ltt_date_to"
       />

--- a/frontend/src/components/filters/FeatureFilters.jsx
+++ b/frontend/src/components/filters/FeatureFilters.jsx
@@ -3,7 +3,7 @@ import { useFilters } from '@/hooks/useFilters'
 
 const { Text } = Typography
 
-function FeatureToggle({ label, filterKey }) {
+export function FeatureToggle({ label, filterKey }) {
   const { filters, setFilter } = useFilters()
   const current = filters[filterKey]
   const yesActive = current === undefined || current === true
@@ -38,7 +38,6 @@ const BOOLEAN_FILTERS = [
   { label: 'Dog friendly',         key: 'is_dog_friendly' },
   { label: 'Snowshoeing',          key: 'has_snowshoeing' },
   { label: 'Allied resort',        key: 'is_allied' },
-  { label: 'Reservation required', key: 'reservation_required' },
 ]
 
 export default function FeatureFilters() {

--- a/frontend/src/components/filters/PeakRankingsFilters.jsx
+++ b/frontend/src/components/filters/PeakRankingsFilters.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Divider, Select, Slider, Typography, theme } from 'antd'
 import { useFilters } from '@/hooks/useFilters'
+import { FeatureToggle } from '@/components/filters/FeatureFilters'
 
 const { Text } = Typography
 
@@ -143,6 +144,7 @@ const CATEGORICAL_FILTERS = [
 export default function PeakRankingsFilters({ meta }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <FeatureToggle label="Has Peak Rankings" filterKey="has_peak_rankings" />
       {SCORE_SLIDERS.map(({ label, field }) => (
         <RangeSlider
           key={field}

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -1,8 +1,9 @@
 import { Button, Divider, Layout, Typography, theme } from 'antd'
 import { COLORS, FONTS } from '@/theme'
 
-export default function AppHeader({ sidebarCollapsed, onToggleSidebar }) {
+export default function AppHeader({ sidebarCollapsed, onToggleSidebar, isMobile }) {
   const { token } = theme.useToken()
+  const height = isMobile ? 40 : 56
   return (
     <Layout.Header
       style={{
@@ -11,8 +12,8 @@ export default function AppHeader({ sidebarCollapsed, onToggleSidebar }) {
         gap: 12,
         background: COLORS.bgHeader,
         padding: '0 24px',
-        height: 56,
-        lineHeight: '56px',
+        height,
+        lineHeight: `${height}px`,
       }}
     >
       <Button
@@ -40,7 +41,7 @@ export default function AppHeader({ sidebarCollapsed, onToggleSidebar }) {
           letterSpacing: '0.08em',
           color: COLORS.error,
           fontWeight: 400,
-          fontSize: 28,
+          fontSize: isMobile ? 20 : 28,
           WebkitFontSmoothing: 'antialiased',
           WebkitTextStroke: `0.5px ${COLORS.error}`,
         }}

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -22,15 +22,19 @@ export default function AppSidebar({ meta, allResorts, collapsed, width, isMobil
     )
   }
 
+  const stickyHeader = { position: 'sticky', top: 0, zIndex: 10, background: token.colorBgLayout }
+
   const items = [
     {
       key: 'location',
       label: sectionLabel('Location', COLORS.primary),
+      styles: { header: stickyHeader },
       children: <LocationFilters meta={meta} allResorts={allResorts ?? []} />,
     },
     {
       key: 'resort-filters',
       label: sectionLabel('Stats and Features', COLORS.accentBlue),
+      styles: { header: stickyHeader },
       children: (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
           <StatsFilters meta={meta} />
@@ -40,12 +44,14 @@ export default function AppSidebar({ meta, allResorts, collapsed, width, isMobil
     },
     {
       key: 'blackout',
-      label: sectionLabel('Blackout Dates', COLORS.error),
+      label: sectionLabel('Planning', COLORS.error),
+      styles: { header: stickyHeader },
       children: <BlackoutDateFilters />,
     },
     {
       key: 'peak-rankings',
       label: sectionLabel('Peak Rankings', COLORS.success),
+      styles: { header: stickyHeader },
       children: <PeakRankingsFilters meta={meta} />,
     },
   ]

--- a/frontend/src/hooks/useFilters.js
+++ b/frontend/src/hooks/useFilters.js
@@ -42,6 +42,8 @@ export function useFilters() {
     is_allied: getBool('is_allied'),
     reservation_required: getBool('reservation_required'),
     ltt_available: getBool('ltt_available'),
+    has_peak_rankings: getBool('has_peak_rankings'),
+    has_blackouts: getBool('has_blackouts'),
     // Blackout date range filters (YYYY-MM-DD strings)
     blackout_date_from: searchParams.get('blackout_date_from'),
     blackout_date_to: searchParams.get('blackout_date_to'),


### PR DESCRIPTION
Closes items from #116 (UI polish queue).

## Changes

**Map tooltip** — reduced from 14 rows to 6 (Resort, Location, Acres, Vertical, Trails, Lifts). US resorts omit country from Location since it's redundant on a map.

**Sidebar filters**
- Sticky section headers (position: sticky) so headers remain visible while scrolling
- "Blackout Dates" section renamed to "Planning"; Reservation Required moved into it
- Planning section restructured with Lift Ticket / Learn to Turn sub-headings
- New "Blackout dates" Yes/No toggle (`has_blackouts` — backend + test)
- New "Has Peak Rankings" Yes/No toggle at top of Peak Rankings section (backend param already existed)
- `FeatureToggle` exported and reused across Planning and Peak Rankings sections
- LTT expanded to "Learn to Turn" throughout filters, table columns, and modal legend

**Table toolbar** — buttons right-aligned on mobile; vertical alignment fixed on desktop

**Mobile chrome** — header 56px→40px, title font 28px→20px, toolbar padding tightened, tab bar 48px→36px; desktop untouched

## Test plan
- [ ] Hover resort dots on map — tooltip shows 6 rows; US resorts show city/state only
- [ ] Hover international resort — country appears in Location
- [ ] Scroll sidebar with all sections expanded — section headers stick
- [ ] Planning section: Reservation Required, Blackout dates toggle, LTT sub-sections render correctly
- [ ] "Blackout dates" Yes/No filters resorts correctly
- [ ] "Has Peak Rankings" Yes/No filters resorts correctly
- [ ] Mobile table view: Select Columns / Download CSV right-aligned
- [ ] Mobile: header and tab bar visibly slimmer than before
- [ ] Backend test suite passes: `poetry run pytest backend/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)