### PR TITLE
feat: How to use modal (#108) + antd v6 fixes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import ResortToolbar from '@/components/ResortToolbar'
 import ResortMap from '@/components/ResortMap'
 import ResortTable, { COLUMN_DEFS, HEADER_BY_FIELD, COL_GROUPS } from '@/components/ResortTable'
 import ResortDetailModal from '@/components/ResortDetailModal'
+import HowToUseModal from '@/components/HowToUseModal'
 import { themeConfig, COLORS, FONTS } from '@/theme'
 
 const DEFAULT_TABLE_HEIGHT = 260
@@ -41,6 +42,13 @@ export default function App() {
   const [tableCollapsed, setTableCollapsed] = useState(false)
   const [mobileTab, setMobileTab] = useState('map')
   const [infoOpen, setInfoOpen] = useState(false)
+  const [howToUseOpen, setHowToUseOpen] = useState(() => !localStorage.getItem('indy-how-to-use-seen'))
+
+  function openHowToUse() { setHowToUseOpen(true) }
+  function closeHowToUse() {
+    localStorage.setItem('indy-how-to-use-seen', '1')
+    setHowToUseOpen(false)
+  }
 
   const tableRef = useRef()
   const [colsOpen,      setColsOpen]      = useState(false)
@@ -181,7 +189,7 @@ export default function App() {
     return (
       <ConfigProvider theme={themeConfig}>
         <Layout style={{ height: '100%' }}>
-          <AppHeader sidebarCollapsed={sidebarCollapsed} onToggleSidebar={() => setSidebarCollapsed(c => !c)} isMobile />
+          <AppHeader sidebarCollapsed={sidebarCollapsed} onToggleSidebar={() => setSidebarCollapsed(c => !c)} onHowToUse={openHowToUse} isMobile />
           <Layout>
             <AppSidebar
               meta={meta}
@@ -300,6 +308,7 @@ export default function App() {
           onClose={() => setSelectedResortId(null)}
           isMobile={isMobile}
         />
+        <HowToUseModal open={howToUseOpen} onClose={closeHowToUse} isMobile />
       </ConfigProvider>
     )
   }
@@ -307,7 +316,7 @@ export default function App() {
   return (
     <ConfigProvider theme={themeConfig}>
       <Layout style={{ height: '100%' }}>
-        <AppHeader sidebarCollapsed={sidebarCollapsed} onToggleSidebar={() => setSidebarCollapsed(c => !c)} />
+        <AppHeader sidebarCollapsed={sidebarCollapsed} onToggleSidebar={() => setSidebarCollapsed(c => !c)} onHowToUse={openHowToUse} />
         <Layout>
           <AppSidebar
             meta={meta}
@@ -406,6 +415,7 @@ export default function App() {
         resortId={selectedResortId}
         onClose={() => setSelectedResortId(null)}
       />
+      <HowToUseModal open={howToUseOpen} onClose={closeHowToUse} />
     </ConfigProvider>
   )
 }

--- a/frontend/src/components/HowToUseModal.jsx
+++ b/frontend/src/components/HowToUseModal.jsx
@@ -85,17 +85,22 @@ export default function HowToUseModal({ open, onClose, isMobile }) {
       onCancel={onClose}
       footer={null}
       closable={false}
-      width={isMobile ? '100vw' : 500}
-      style={{ top: gap, margin: isMobile ? 0 : '0 auto', padding: 0 }}
+      centered={isMobile}
+      width={isMobile ? '100%' : 500}
+      style={{
+        top: isMobile ? undefined : gap,
+        margin: isMobile ? 0 : '0 auto',
+        padding: 0,
+        maxWidth: isMobile ? '100vw' : undefined,
+      }}
       styles={{
         wrapper: { padding: 0 },
-        // Suppress any Ant Design default header element
         header: { display: 'none', padding: 0, height: 0, margin: 0 },
         content: {
           padding: 0,
           overflow: 'hidden',
           borderRadius: isMobile ? 0 : 2,
-          height: isMobile ? '100vh' : `calc(100vh - ${gap * 2}px)`,
+          height: isMobile ? '100dvh' : `calc(100vh - ${gap * 2}px)`,
           display: 'flex',
           flexDirection: 'column',
         },

--- a/frontend/src/components/HowToUseModal.jsx
+++ b/frontend/src/components/HowToUseModal.jsx
@@ -95,22 +95,15 @@ export default function HowToUseModal({ open, onClose, isMobile }) {
       }}
       styles={{
         wrapper: { padding: 0 },
-        header: { display: 'none', padding: 0, height: 0, margin: 0 },
-        content: {
-          padding: 0,
+        container: {
+          padding: isMobile ? 0 : 2,
           overflow: 'hidden',
-          borderRadius: isMobile ? 0 : 2,
-          height: isMobile ? '100dvh' : `calc(100vh - ${gap * 2}px)`,
-          display: 'flex',
-          flexDirection: 'column',
+          borderRadius: isMobile ? 0 : undefined,
+          ...(isMobile ? { height: '100dvh', display: 'flex', flexDirection: 'column' } : {}),
         },
         body: {
           padding: 0,
-          flex: 1,
-          overflow: 'hidden',
-          display: 'flex',
-          flexDirection: 'column',
-          minHeight: 0,
+          ...(isMobile ? { flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 } : {}),
         },
       }}
     >
@@ -118,7 +111,6 @@ export default function HowToUseModal({ open, onClose, isMobile }) {
       <div style={{
         background: COLORS.bgHeader,
         padding: '10px 12px 10px 24px',
-        flexShrink: 0,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
@@ -148,7 +140,7 @@ export default function HowToUseModal({ open, onClose, isMobile }) {
       </div>
 
       {/* Scrollable content */}
-      <div style={{ overflowY: 'auto', flex: 1, padding: '16px 24px 24px' }}>
+      <div style={{ overflowY: 'auto', flex: isMobile ? 1 : undefined, maxHeight: isMobile ? undefined : `calc(100vh - ${gap * 2 + 60}px)`, padding: '16px 24px 24px' }}>
         <p style={{ fontFamily: FONTS.mono, fontSize: 13, color: COLORS.textMuted, marginTop: 0, marginBottom: 20, lineHeight: 1.6 }}>
           Indy Explorer helps you find the right{' '}
           <span style={{ color: COLORS.error }}>Indy Pass</span>{' '}

--- a/frontend/src/components/HowToUseModal.jsx
+++ b/frontend/src/components/HowToUseModal.jsx
@@ -1,0 +1,172 @@
+import { Modal } from 'antd'
+import { COLORS, FONTS } from '@/theme'
+
+function Btn({ children, variant }) {
+  const isDanger = variant === 'danger'
+  return (
+    <span style={{
+      display: 'inline-block',
+      background: isDanger ? COLORS.error : COLORS.bgHeader,
+      color: isDanger ? '#ffffff' : COLORS.error,
+      fontFamily: FONTS.mono,
+      fontSize: 12,
+      fontWeight: 700,
+      padding: '1px 6px',
+      borderRadius: 2,
+      border: `1px solid ${isDanger ? COLORS.error : COLORS.bgMidtone}`,
+      whiteSpace: 'nowrap',
+      verticalAlign: 'middle',
+    }}>
+      {children}
+    </span>
+  )
+}
+
+function desktopSections() {
+  return [
+    {
+      heading: 'Filters',
+      body: <>
+        The sidebar on the left lets you filter by region, terrain type, features, blackout dates, and Peak Rankings score.
+        Use the <Btn>≪</Btn> button in the header to collapse or expand it.
+      </>,
+    },
+    {
+      heading: 'Map',
+      body: <>
+        Each dot is a resort — <span style={{ color: COLORS.error }}>pink</span> = alpine, <span style={{ color: COLORS.accentBlue }}>blue</span> = cross-country, <span style={{ color: COLORS.accentPurple }}>purple</span> = both. Click any dot to open its detail view.
+      </>,
+    },
+    {
+      heading: 'Table',
+      body: <>
+        Click <Btn variant="danger">▲ Expand data table</Btn> at the bottom to show the sortable resort table. Click any row to open the detail view.
+      </>,
+    },
+    {
+      heading: 'Resort detail',
+      body: <>
+        Opens from any map dot or table row. Shows trail breakdown, snowfall, blackout dates, and Peak Rankings score.
+      </>,
+    },
+  ]
+}
+
+function mobileSections() {
+  return [
+    {
+      heading: 'Filters',
+      body: <>
+        Tap the <Btn>≫</Btn> button in the top-left to open the filter sidebar. Filter by region, features, blackout dates, and Peak Rankings score.
+      </>,
+    },
+    {
+      heading: 'Map & Table',
+      body: <>
+        Switch views using the <Btn>Map</Btn> and <Btn>Table</Btn> tabs at the bottom of the screen. Dots are color-coded: <span style={{ color: COLORS.error }}>pink</span> = alpine, <span style={{ color: COLORS.accentBlue }}>blue</span> = cross-country, <span style={{ color: COLORS.accentPurple }}>purple</span> = both.
+      </>,
+    },
+    {
+      heading: 'Resort detail',
+      body: <>
+        Tap any map dot or table row to open the resort detail view — trail breakdown, snowfall, blackout dates, and Peak Rankings score.
+      </>,
+    },
+  ]
+}
+
+export default function HowToUseModal({ open, onClose, isMobile }) {
+  const sections = isMobile ? mobileSections() : desktopSections()
+  const gap = isMobile ? 0 : 16
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      closable={false}
+      width={isMobile ? '100vw' : 500}
+      style={{ top: gap, margin: isMobile ? 0 : '0 auto', padding: 0 }}
+      styles={{
+        wrapper: { padding: 0 },
+        // Suppress any Ant Design default header element
+        header: { display: 'none', padding: 0, height: 0, margin: 0 },
+        content: {
+          padding: 0,
+          overflow: 'hidden',
+          borderRadius: isMobile ? 0 : 2,
+          height: isMobile ? '100vh' : `calc(100vh - ${gap * 2}px)`,
+          display: 'flex',
+          flexDirection: 'column',
+        },
+        body: {
+          padding: 0,
+          flex: 1,
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+        },
+      }}
+    >
+      {/* Header — fixed, never scrolls */}
+      <div style={{
+        background: COLORS.bgHeader,
+        padding: '10px 12px 10px 24px',
+        flexShrink: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+      }}>
+        <span style={{ fontFamily: FONTS.display, fontSize: 22, letterSpacing: '0.06em', color: COLORS.error }}>
+          How to use Indy Explorer
+        </span>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          style={{
+            background: 'none',
+            border: 'none',
+            color: COLORS.error,
+            fontSize: 22,
+            fontWeight: 700,
+            fontFamily: FONTS.mono,
+            cursor: 'pointer',
+            padding: '4px 10px',
+            lineHeight: 1,
+            flexShrink: 0,
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Scrollable content */}
+      <div style={{ overflowY: 'auto', flex: 1, padding: '16px 24px 24px' }}>
+        <p style={{ fontFamily: FONTS.mono, fontSize: 13, color: COLORS.textMuted, marginTop: 0, marginBottom: 20, lineHeight: 1.6 }}>
+          Indy Explorer helps you find the right{' '}
+          <span style={{ color: COLORS.error }}>Indy Pass</span>{' '}
+          resort — filter by location, features, and dates, then dig into the data.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          {sections.map(({ heading, body }) => (
+            <div key={heading} style={{ borderLeft: `3px solid ${COLORS.primary}`, paddingLeft: 12 }}>
+              <div style={{ fontFamily: FONTS.mono, fontWeight: 700, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', color: COLORS.primary, marginBottom: 4 }}>
+                {heading}
+              </div>
+              <div style={{ fontFamily: FONTS.mono, fontSize: 12, color: COLORS.text, lineHeight: 1.6 }}>
+                {body}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ marginTop: 20, borderTop: `1px solid ${COLORS.border}`, paddingTop: 12, fontFamily: FONTS.mono, fontSize: 11, color: COLORS.textMuted }}>
+          Data from Indy Pass, Peak Rankings, and Google Maps. Not affiliated with Indy Pass.
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -1,7 +1,7 @@
 import { Button, Divider, Layout, Typography, theme } from 'antd'
 import { COLORS, FONTS } from '@/theme'
 
-export default function AppHeader({ sidebarCollapsed, onToggleSidebar, isMobile }) {
+export default function AppHeader({ sidebarCollapsed, onToggleSidebar, onHowToUse, isMobile }) {
   const { token } = theme.useToken()
   const height = isMobile ? 40 : 56
   return (
@@ -44,10 +44,26 @@ export default function AppHeader({ sidebarCollapsed, onToggleSidebar, isMobile 
           fontSize: isMobile ? 20 : 28,
           WebkitFontSmoothing: 'antialiased',
           WebkitTextStroke: `0.5px ${COLORS.error}`,
+          flex: 1,
         }}
       >
         Indy Explorer
       </Typography.Title>
+      <Button
+        type="text"
+        onClick={onHowToUse}
+        aria-label="How to use"
+        style={{
+          color: COLORS.textMuted,
+          fontFamily: FONTS.mono,
+          fontSize: isMobile ? 12 : 13,
+          padding: '0 8px',
+          flexShrink: 0,
+          lineHeight: 1,
+        }}
+      >
+        ?
+      </Button>
     </Layout.Header>
   )
 }

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -91,7 +91,7 @@ export default function AppSidebar({ meta, allResorts, collapsed, width, isMobil
         placement="left"
         open={!collapsed}
         onClose={onClose}
-        width={280}
+        size={280}
         styles={{ body: { padding: 0, background: token.colorBgLayout } }}
       >
         {content}


### PR DESCRIPTION
## Summary

- Adds a "How to use" first-load popover (`HowToUseModal`) gated by `localStorage` — shows once per browser, dismissed via ✕ or clicking the overlay. Desktop and mobile have tailored content.
- Fixes modal layout for antd v6: `styles.content` was renamed to `styles.container` and was silently ignored, leaving a ~20px default padding gap. Desktop modal now sizes to content (no forced full-height flex).
- Applies 2px container padding so the dark header has a thin white frame against the modal border.
- Fixes `Drawer` deprecation warning: `width={280}` → `size={280}` (antd v6 API).

## Test plan

- [ ] Clear `localStorage.removeItem('howToUseSeen')` in the browser console, refresh — popover appears on load
- [ ] Close via ✕ button, refresh — popover does not reappear
- [ ] On desktop: modal is content-sized (no blank whitespace at bottom), dark header has a thin white border around it
- [ ] On mobile: modal is full-screen, content scrollable
- [ ] Sidebar filter drawer opens correctly on mobile at ~280px width
- [ ] No antd Drawer deprecation warning in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)