### PR TITLE
chore: scope Playwright MCP output to gitignored .playwright-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ docs/ops-runbook.md
 .cursor/
 .aider*
 .copilot/
+
+# Playwright MCP output (screenshots, snapshots, console/network logs)
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,12 @@ poetry run python pipeline/prep_resort_data.py                      # merge all 
 - Backend tests live in `backend/tests/` and run separately: `cd backend && pytest tests/`
 - CI runs three jobs: Format (Black), Test suite (pipeline), Backend test suite
 
+## Playwright MCP (Visual Verification)
+
+- All Playwright MCP output — screenshots, accessibility snapshots, console/network logs — belongs in `.playwright-mcp/` at the repo root. That directory is gitignored.
+- When calling `browser_take_screenshot`, always pass a `filename` scoped to that directory, e.g. `.playwright-mcp/<name>.png`, so artifacts don't land at the repo root.
+- Start the backend (`localhost:8000`) and frontend (`localhost:5173`) dev servers first (see Commands above), then navigate Playwright to `http://localhost:5173/`.
+
 ## Code Style
 
 - Black with `line-length = 100` and `skip-string-normalization = true` (preserves single quotes)


### PR DESCRIPTION
## Summary
- Ignore `.playwright-mcp/` (screenshots, accessibility snapshots, console/network logs from the Playwright MCP tool) so it stops landing in the repo root or being tracked as untracked cruft
- Document the convention in `CLAUDE.md` — future sessions should scope `browser_take_screenshot` filenames to `.playwright-mcp/<name>.png` and start the dev servers before navigating there

Fixes #124

## Test plan
- [x] Verified `.playwright-mcp/` no longer appears in `git status` after adding to `.gitignore`
- [x] `poetry run black --check .` (no Python changes, but confirming no formatting drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)